### PR TITLE
Small fix to exceptions

### DIFF
--- a/mclevel.py
+++ b/mclevel.py
@@ -1785,9 +1785,11 @@ class InfdevChunk(MCLevel):
         return self.root_tag[Level][TileEntities]
     
     @property
+    @decompress_first   
     def TerrainPopulated(self):
         return self.root_tag[Level]["TerrainPopulated"].value;
     @TerrainPopulated.setter
+    @decompress_first
     def TerrainPopulated(self, val):
         """True or False. If False, the game will populate the chunk with 
         ores and vegetation on next load"""


### PR DESCRIPTION
Because the chunk value TerrainPopulated wasn't decompressing (if needed) the chunk, if you tried to access it before reading one of the other, properly-decorated properties, you got an 'NoneType' TypeError exception. Same with property assignment.

This fixes it (in my test case) by simply adding the decorator.
