### PR TITLE
Tilde Expansion / Commands To Search for Mob Spawners

### DIFF
--- a/mce.py
+++ b/mce.py
@@ -2,6 +2,7 @@
 import mclevel
 import sys
 import os
+import os.path
 from box import BoundingBox
 import numpy
 from numpy import zeros, bincount
@@ -1137,6 +1138,7 @@ class mce(object):
         try:
             worldNum = int(world)
         except ValueError:
+            world = os.path.expanduser(world)
             self.level = mclevel.fromFile(world)
             
             self.filename = self.level.filename


### PR DESCRIPTION
I got tired of typing /home/user/blah.  Now ~/blah works.  Should work on Windows as well.

Added a command "dungeons" that finds mob spawners and prioritizes them by accessibility.
