### PR TITLE
More finegrained loggers (issue #53)

### DIFF
--- a/indev.py
+++ b/indev.py
@@ -63,6 +63,9 @@ TAG_Compound "MinecraftLevel"
 """
 from mclevelbase import *
 
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
+
 MinecraftLevel = "MinecraftLevel"
 
 Environment = "Environment"

--- a/infiniteworld.py
+++ b/infiniteworld.py
@@ -14,6 +14,9 @@ import sys
 import urllib
 import tempfile
 
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
+
 #infinite
 Level = 'Level'
 BlockData = 'BlockData'

--- a/java.py
+++ b/java.py
@@ -8,6 +8,9 @@ from mclevelbase import *
 
 import re
 
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
+
 
 class MCJavaLevel(MCLevel):
 

--- a/level.py
+++ b/level.py
@@ -9,6 +9,9 @@ from mclevelbase import *
 import tempfile
 from collections import defaultdict
 
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
+
 def extractLightMap(materials, blocks, heightMap = None):
     """Computes the HeightMap array for a chunk, which stores the lowest 
     y-coordinate of each column where the sunlight is still at full strength."""

--- a/mclevel.py
+++ b/mclevel.py
@@ -170,7 +170,7 @@ def fillBlocks(self, box, blockType, blockData = 0):
 Copyright 2010 David Rio Vierra
 """
 import os
-from logging import warn, error, info, debug
+import logging
 from numpy import fromstring
 import nbt
 
@@ -182,6 +182,9 @@ from level import *
 from schematic import *
 
 import sys
+
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
 
 
  
@@ -307,7 +310,6 @@ def loadWorldNumber(i):
 ####xxxxx CHECK RESULTS
 #
 ##import cProfile   
-#import logging
 #if __name__=="__main__":
 #    #cProfile.run('testmain()');
 #    logging.basicConfig(format=u'%(levelname)s:%(message)s')

--- a/mclevelbase.py
+++ b/mclevelbase.py
@@ -13,7 +13,7 @@ from contextlib import closing
 import gzip
 
 from numpy import *
-from logging import warn, error, info, debug
+import logging
 
 import nbt
 from nbt import *
@@ -24,6 +24,9 @@ from entity import *
 
 from faces import *
 #String constants for common tag names
+
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
 
 Entities = "Entities"
 TileEntities = "TileEntities"

--- a/schematic.py
+++ b/schematic.py
@@ -5,6 +5,10 @@ Created on Jul 22, 2011
 '''
 from mclevelbase import *
 import shutil
+
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
+
 #schematic
 Materials = 'Materials'
 

--- a/tests.py
+++ b/tests.py
@@ -20,7 +20,8 @@ from numpy import *
 from pymclevel.infiniteworld import MCServerChunkGenerator
 
 log = logging.getLogger(__name__)
-info = log.info
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
+
 #logging.basicConfig(format=u'%(levelname)s:%(message)s')
 #logging.getLogger().level = logging.INFO
 

--- a/tests.py
+++ b/tests.py
@@ -17,8 +17,10 @@ import shutil
 import os
 import numpy
 from numpy import *
-from logging import info
 from pymclevel.infiniteworld import MCServerChunkGenerator
+
+log = logging.getLogger(__name__)
+info = log.info
 #logging.basicConfig(format=u'%(levelname)s:%(message)s')
 #logging.getLogger().level = logging.INFO
 
@@ -240,10 +242,10 @@ class TestSchematics(unittest.TestCase):
     def testINVEditChests(self):
         info("INVEdit chest")
         invFile = fromFile("schematics/Chests/TinkerersBox.inv");
-        info("Blocks: ", invFile.Blocks)
-        info("Data: ", invFile.Data)
-        info("Entities: ", invFile.Entities)
-        info("TileEntities: ", invFile.TileEntities)
+        info("Blocks: %s", invFile.Blocks)
+        info("Data: %s", invFile.Data)
+        info("Entities: %s", invFile.Entities)
+        info("TileEntities: %s", invFile.TileEntities)
         #raise SystemExit;
 
 class TestServerGen(unittest.TestCase):


### PR DESCRIPTION
These changes instantiate more fine-grained loggers that will all inherit from a logger named "pymclevel" (all names follow the names of the library modules), rather than logging to the root logger.
