### PR TITLE
Added allStairs for pocketMaterials to allow MCEdit to load pocket edition levels

### DIFF
--- a/materials.py
+++ b/materials.py
@@ -324,6 +324,8 @@ pocketMaterials = MCMaterials()
 pocketMaterials.name = "Pocket"
 pocketMaterials.addYamlBlocksFromFile("pocket.yaml")
 
+pocketMaterials.AllStairs = [b for b in pocketMaterials.allBlocks if b.name.endswith("Stairs")]
+
 # --- Static block defs ---
 
 alphaMaterials.Stone = alphaMaterials[1, 0]


### PR DESCRIPTION
Copied and pasted the line that generates the stairs for alpha materials. 
This allows MCEdit to load Pocket Edition worlds again.
