### PR TITLE
Rewrite gametype command in mce.py

### DIFF
--- a/infiniteworld.py
+++ b/infiniteworld.py
@@ -2896,6 +2896,44 @@ class MCInfdevOldLevel(ChunkedLevelMixin, EntityLevel):
         yp = y, p;
         return array(yp);
 
+    def setPlayerAbilities(self, gametype, player="Player"):
+        playerTag = self.getPlayerTag(player)
+
+        # Check for the Abilities tag.  It will be missing in worlds from before
+        # Beta 1.9 Prelease 5.
+        if not 'abilities' in playerTag:
+            playerTag['abilities'] = TAG_Compound()
+
+        # Assumes creative (1) is the only mode with these abilities set,
+        # which is true for now.  Future game modes may not hold this to be
+        # true, however.
+        if gametype == 1:
+            playerTag['abilities']['instabuild'] = TAG_Byte(1)
+            playerTag['abilities']['mayfly'] = TAG_Byte(1)
+            playerTag['abilities']['invulnerable'] = TAG_Byte(1)
+        else:
+            playerTag['abilities']['flying'] = TAG_Byte(0)
+            playerTag['abilities']['instabuild'] = TAG_Byte(0)
+            playerTag['abilities']['mayfly'] = TAG_Byte(0)
+            playerTag['abilities']['invulnerable'] = TAG_Byte(0)
+
+    def setPlayerGameType(self, gametype, player="Player"):
+        playerTag = self.getPlayerTag(player)
+        # This annoyingly works differently between single- and multi-player.
+        if player == "Player":
+            self.GameType = gametype
+            self.setPlayerAbilities(gametype, player)
+        else:
+            playerTag['playerGameType'] = TAG_Int(gametype)
+            self.setPlayerAbilities(gametype, player)
+
+    def getPlayerGameType(self, player="Player"):
+        if player == "Player":
+            return self.GameType
+        else:
+            playerTag = self.getPlayerTag(player)
+            return playerTag["playerGameType"].value
+
 class MCAlphaDimension (MCInfdevOldLevel):
     def __init__(self, parentWorld, dimNo, create=False):
         filename = os.path.join(parentWorld.worldDir, "DIM" + str(int(dimNo)))

--- a/infiniteworld.py
+++ b/infiniteworld.py
@@ -2900,7 +2900,7 @@ class MCInfdevOldLevel(ChunkedLevelMixin, EntityLevel):
         playerTag = self.getPlayerTag(player)
 
         # Check for the Abilities tag.  It will be missing in worlds from before
-        # Beta 1.9 Prelease 5.
+        # Beta 1.9 Prerelease 5.
         if not 'abilities' in playerTag:
             playerTag['abilities'] = TAG_Compound()
 

--- a/mce.py
+++ b/mce.py
@@ -1088,21 +1088,30 @@ class mce(object):
 
     def _gametype(self, command):
         """
-    gametype [ <gametype> ]
+    gametype [ <player> [ <gametype> ] ]
 
-    Set or display the world's game type, an integer that identifies whether
-    the game is survival (0) or creative (1).
+    Set or display the player's game type, an integer that identifies whether
+    their game is survival (0) or creative (1).  On single-player worlds, the
+    player is just 'Player'.
     """
-        if len(command):
-            try:
-                gametype = int(command[0])
-            except ValueError:
-                raise UsageError, "Expected an integer."
+        if len(command) == 0:
+            print "Players: "
+            for player in self.level.players:
+                print "    {0}: {1}".format(player, self.level.getPlayerGameType(player))
+            return
 
-            self.level.GameType = gametype
-            self.needsSave = True
-        else:
-            print "Game Type: ", self.level.GameType
+        player = command.pop(0)
+        if len(command) == 0:
+            print "Player {0}: {1}".format(player, self.level.getPlayerGameType(player))
+            return
+
+        try:
+            gametype = int(command[0])
+        except ValueError:
+            raise UsageError, "Expected an integer."
+
+        self.level.setPlayerGameType(gametype, player)
+        self.needsSave = True
 
     def _worldsize(self, command):
         """

--- a/mce.py
+++ b/mce.py
@@ -57,7 +57,7 @@ class mce(object):
        {commandPrefix}worldsize       
        {commandPrefix}heightmap <filename>
        {commandPrefix}randomseed [ <seed> ]
-       {commandPrefix}gametype [ <gametype> ]
+       {commandPrefix}gametype [ <player> [ <gametype> ] ]
        
     Editor commands:
        {commandPrefix}save 


### PR DESCRIPTION
Now supports both single- and multi-player worlds, and it also
sets the player abilities added in Beta 1.9-pre5 to proper values
based on the gametype changed to.  No longer will allow flying and
invulnerable players when switching to survival mode!

An additional thought i debated with myself, was to really stick with having to use numbers having the names "creative" and "survival" to be typed out.  I ultimately decided against it -- the numbers are the same thing server ops have to type to switch players on a live server, and any future game modes (eg, adventure) wouldn't need any code changes (hopefully! -- abilities may need to be changed).
