### PR TITLE
Fixed the problem with Pocket Edition Levels with testing271 of MCEdit

### DIFF
--- a/pocket.py
+++ b/pocket.py
@@ -378,6 +378,9 @@ class PocketChunk(InfdevChunk):
     def load(self): pass
     def decompress(self): pass
     def compress(self): pass
+
+    @property
+    def TerrainPopulated(self): return True;
     
     def unpackChunkData(self):
         for key in ('SkyLight', 'BlockLight', 'Data'):


### PR DESCRIPTION
I've added a terrainPopulated getter to PocketChunk, which seems to make MCEdit load Pocket Edition levels again.
