### PR TITLE
fix the rest of the import alls, import order for logging in tests.py and a couple of .gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,9 @@ build
 #profiling/outputs
 *.log
 
+# Accelerated NBT build
+_nbt.c
+_nbt.so
+
 # The "standard" virtualenv directory.
 ENV

--- a/__init__.py
+++ b/__init__.py
@@ -1,15 +1,14 @@
 from box import BoundingBox, FloatBox
 from entity import Entity, TileEntity
-from faces import *
-from indev import *
-from infiniteworld import *
+from faces import faceDirections, FaceXDecreasing, FaceXIncreasing, FaceYDecreasing, FaceYIncreasing, FaceZDecreasing, FaceZIncreasing, MaxDirections
+from indev import MCIndevLevel
+from infiniteworld import ChunkedLevelMixin, InfdevChunk, MCAlphaDimension, MCInfdevOldLevel, ZeroChunk, ZipSchematic
 import items
-from java import *
-from level import *
-from materials import *
-from mclevelbase import saveFileDir, minecraftDir
+from java import MCJavaLevel
+from level import ChunkBase, computeChunkHeightMap, EntityLevel, FakeChunk, LightedChunk, MCLevel
+from materials import alphaMaterials, classicMaterials, indevMaterials, MCMaterials, namedMaterials, pocketMaterials
+from mclevelbase import saveFileDir, minecraftDir, PlayerNotFound
 from mclevel import fromFile, loadWorld, loadWorldNumber
-from nbt import *
-from pocket import pocketMaterials
+from nbt import load, gunzip, TAG_Byte, TAG_Byte_Array, TAG_Compound, TAG_Double, TAG_Float, TAG_Int, TAG_Int_Array, TAG_List, TAG_Long, TAG_Short, TAG_String
 import pocket
-from schematic import *
+from schematic import INVEditChest, MCSchematic

--- a/nbt.py
+++ b/nbt.py
@@ -4,14 +4,14 @@ logger = logging.getLogger(__file__)
 
 try:
     try:
-        from _nbt import *
+        from _nbt import load, gunzip, TAG_Byte, TAG_Byte_Array, TAG_Compound, TAG_Double, TAG_Float, TAG_Int, TAG_Int_Array, TAG_List, TAG_Long, TAG_Short, TAG_String
         logger.info("Accelerated NBT module loaded.")
     except ImportError:
         logger.info("Import error loading precompiled _nbt extension. Trying pyximport...")
         import numpy
         from pyximport import install
         install(setup_args={'include_dirs': [numpy.get_include()]})
-        from _nbt import *
+        from _nbt import load, gunzip, TAG_Byte, TAG_Byte_Array, TAG_Compound, TAG_Double, TAG_Float, TAG_Int, TAG_Int_Array, TAG_List, TAG_Long, TAG_Short, TAG_String
         logger.info("Accelerated NBT module loaded via pyximport.")
 except ImportError, e:
     logger.info("Exception: ", repr(e))
@@ -32,5 +32,5 @@ command to install Cython:
 
     sudo apt-get install gcc
 """)
-    from pynbt import *
+    from pynbt import load, gunzip, TAG_Byte, TAG_Byte_Array, TAG_Compound, TAG_Double, TAG_Float, TAG_Int, TAG_Int_Array, TAG_List, TAG_Long, TAG_Short, TAG_String
     logger.info("Pure-python NBT module loaded.")

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,14 @@ Created on Jul 23, 2011
 @author: Rio
 '''
 
+import logging
+
+log = logging.getLogger(__name__)
+warn, error, info, debug = log.warn, log.error, log.info, log.debug
+
+# logging.basicConfig(format=u'%(levelname)s:%(message)s')
+# logging.getLogger().level = logging.INFO
+
 # from mclevel import loadWorldNumber, BoundingBox
 # import errorreporting  # annotate tracebacks with call arguments
 
@@ -12,7 +20,6 @@ from cStringIO import StringIO
 from entity import Entity, TileEntity
 from infiniteworld import MCInfdevOldLevel, MCServerChunkGenerator
 import itertools
-import logging
 import mclevel
 import nbt
 import numpy
@@ -23,12 +30,6 @@ import shutil
 import tempfile
 import time
 import unittest
-
-log = logging.getLogger(__name__)
-warn, error, info, debug = log.warn, log.error, log.info, log.debug
-
-# logging.basicConfig(format=u'%(levelname)s:%(message)s')
-# logging.getLogger().level = logging.INFO
 
 
 def mktemp(suffix):


### PR DESCRIPTION
**init**.py and nbt.py now also don't use 'import *'.  When uncommented, the logging in tests.py is now configured before other modules are imported.  Add _nbt related files to .gitignore.
