### PR TITLE
Added `box.positions`, to complement `box.chunkPositions`.

### DIFF
--- a/box.py
+++ b/box.py
@@ -144,8 +144,12 @@ class BoundingBox (object):
 
     @property
     def positions(self):
-        #iterate through all of the positions within this selection box
-        return itertools.product(xrange(self.minx, self.maxx), xrange(self.miny, self.maxy), xrange(self.minz, self.maxz))
+        """iterate through all of the positions within this selection box"""
+        return itertools.product(
+            xrange(self.minx, self.maxx),
+            xrange(self.miny, self.maxy),
+            xrange(self.minz, self.maxz)
+        )
 
     @property
     def chunkCount(self):

--- a/box.py
+++ b/box.py
@@ -143,6 +143,11 @@ class BoundingBox (object):
         return itertools.product(xrange(self.mincx, self.maxcx), xrange(self.mincz, self.maxcz))
 
     @property
+    def positions(self):
+        #iterate through all of the positions within this selection box
+        return itertools.product(xrange(self.minx, self.maxx), xrange(self.miny, self.maxy), xrange(self.minz, self.maxz))
+
+    @property
     def chunkCount(self):
         return (self.maxcx - self.mincx) * (self.maxcz - self.mincz)
 


### PR DESCRIPTION
This seems to be a very common use of the box class, so I feel this should be in the library:

``` python
for x, y, z in box.positions:
    if level.blockAt(x, y, z) == theBlock:
        level.setBlockAt(x, y, z, theOtherBlock)
```
