### PR TITLE
Ensure that filling worlds is done with the same kind of file format

### DIFF
--- a/infiniteworld.py
+++ b/infiniteworld.py
@@ -2384,7 +2384,7 @@ class MCInfdevOldLevel(ChunkedLevelMixin, EntityLevel):
             random_seed = long(random.random() * 0xffffffffffffffffL) - 0x8000000000000000L
 
         self.root_tag = root_tag
-        root_tag[Data]['version'] = nbt.TAG_Int(self.VERSION_MCR)
+        root_tag[Data]['version'] = nbt.TAG_Int(self.VERSION_ANVIL)
 
         self.LastPlayed = long(last_played)
         self.RandomSeed = long(random_seed)


### PR DESCRIPTION
This is necessary for MCServerChunkGeneratort.tempWorldForLevel for example

A better fix would be necesseray, like adding a 'version' parameter to MCInfdevOldLevel constructor.
