### PR TITLE
Support dimensions with arbitrary directory names.

### DIFF
--- a/level.py
+++ b/level.py
@@ -147,6 +147,7 @@ class MCLevel(object):
     dimNo = 0
     parentWorld = None
     world = None
+    directory = None
 
     @classmethod
     def isLevel(cls, filename):

--- a/mce.py
+++ b/mce.py
@@ -1286,13 +1286,12 @@ class mce(object):
     dimension [ <dim> ]
 
     Load another dimension, a sub-world of this level. Without options, lists
-    all of the dimensions found in this world. <dim> can be a number or one of
-    these keywords:
+    all of the dimensions found in this world. <dim> can be a number, a 
+    directory or one of these keywords:
         nether, hell, slip: DIM-1
         earth, overworld, parent: parent world
         end: DIM1
     """
-
         if len(command):
             if command[0].lower() in ("earth", "overworld", "parent"):
                 if self.level.parentWorld:
@@ -1307,10 +1306,14 @@ class mce(object):
             elif command[0].lower() in ("end"):
                 dimNo = 1
             else:
-                dimNo = self.readInt(command)
+                dirname = None
+                dimNo = None
+                try:
+                    dimNo = int(command[0])
+                except ValueError:
+                    dirname = command[0]
 
-            if dimNo in self.level.dimensions:
-                self.level = self.level.dimensions[dimNo]
+                self.level = self.level.getDimension(dimNo, dirname)
                 return
 
         if self.level.parentWorld:
@@ -1318,7 +1321,7 @@ class mce(object):
 
         if len(self.level.dimensions):
             print u"Dimensions in {0}:".format(self.level.displayName)
-            for k in self.level.dimensions:
+            for k in self.level.dimensions.values():
                 print "{0}: {1}".format(k, infiniteworld.MCAlphaDimension.dimensionNames.get(k, "Unknown"))
 
     def _help(self, command):


### PR DESCRIPTION
With this patch, dimension directories no longer have to be in the format "DIM-_n_".  

To the best of my knowledge, this should have no backward-compatibility effect for programs that use this library, with one exception:  applications that access `MCInfdevOldLevel`'s `dimensions` hash instead of calling `getDimension()`.  This is because `dimensions`'s key was the dimNo of a dimension, which may not be a meaningful number for worlds that do not follow the "DIM-_n_" format.  The key is now the name of the dimension's directory.

For the mcedit counterpart of this patch, see https://github.com/mcedit/mcedit/issues/122
