### PR TITLE
"compressed" option for nbt.load()

### DIFF
--- a/_nbt.pyx
+++ b/_nbt.pyx
@@ -445,14 +445,17 @@ def try_gunzip(data):
     return data
 
 
-def load(filename="", buf=None):
+def load(filename="", buf=None, compressed=True):
     if filename:
         buf = file(filename, "rb")
 
     if hasattr(buf, "read"):
         buf = buf.read()
 
-    return load_buffer(try_gunzip(buf))
+    if compressed is True:
+        return load_buffer(try_gunzip(buf))
+    else
+        return load_buffer(buf)
 
 
 cdef class load_ctx:

--- a/nbt.py
+++ b/nbt.py
@@ -502,7 +502,7 @@ def try_gunzip(data):
     return data
 
 
-def load(filename="", buf=None):
+def load(filename="", buf=None, compressed=True):
     """
     Unserialize data from an NBT file and return the root TAG_Compound object. If filename is passed,
     reads from the file, otherwise uses data from buf. Buf can be a buffer object with a read() method or a string
@@ -514,7 +514,10 @@ def load(filename="", buf=None):
     if hasattr(buf, "read"):
         buf = buf.read()
 
-    return _load_buffer(try_gunzip(buf))
+    if compressed is True:
+        return _load_buffer(try_gunzip(buf))
+    else:
+        return _load_buffer(buf)
 
 class load_ctx(object):
     pass


### PR DESCRIPTION
nbt.load() seems to have trouble with non-compressed nbt files. (Try loading data/idcounts.dat, for example). This adds a compressed option to load() much like the same option for save() that forces compression off. 
