### PR TITLE
Update for 0.8.0build2

### DIFF
--- a/pocket.yaml
+++ b/pocket.yaml
@@ -48,6 +48,19 @@ blocks:
     name: Wood Planks
     mapcolor: [157, 128, 79]
     tex: [4, 0]
+    data:
+      0:
+        name: Wood Planks
+        tex: [4, 0]
+      1:
+        name: Wood Planks
+        tex: [6, 12]
+      2:
+        name: Wood Planks
+        tex: [6, 13]
+      3:
+        name: Wood Planks
+        tex: [7, 12]
 
   - id: 6
     idStr: SAPLING
@@ -155,6 +168,9 @@ blocks:
       2:
         name: Birch Wood
         tex: [5, 7]
+      3:
+        name: Jungle Wood
+        tex: [9, 9]
 
   - id: 18
     idStr: LEAVES
@@ -191,6 +207,16 @@ blocks:
         name: Birch Leaves (Decaying)
         mapcolor: [89, 151, 76]
         tex: [5, 3]
+      7:
+        name: Jungle Leaves (Decaying)
+        mapcolor: [74, 131, 66]
+        tex: [5, 12]
+    
+  - id: 19
+    idStr: sponge
+    name: Sponge
+    mapcolor: [193, 193, 57]
+    tex: [0, 3]
 
   - id: 20
     idStr: GLASS
@@ -220,6 +246,27 @@ blocks:
     tex_direction:
       TOP: [0, 11]
       BOTTOM: [0, 13]
+    data:
+      0:
+        name: Sandstone
+        mapcolor: [218, 210, 158]
+        tex: [0, 12]
+      1:
+        name: Sandstone
+        aka: Decorative Sandstone
+        mapcolor: [218, 210, 158]
+        tex: [5, 14]
+        tex_direction:
+          TOP: [0, 11]
+          BOTTOM: [0, 11]
+      2:
+        name: Sandstone
+        aka: Smooth Sandstone
+        mapcolor: [218, 210, 158]
+        tex: [6, 14]
+        tex_direction:
+          TOP: [0, 11]
+          BOTTOM: [0, 11]
 
   - id: 26
     idStr: BED
@@ -233,6 +280,16 @@ blocks:
       foot_side: [6, 9]
       foot: [5, 9]
       head: [8, 9]
+    opacity: 0
+    
+  - id: 27
+    idStr: goldenRail
+    name: Powered Rail
+    mapcolor: [120, 53, 28]
+    tex: [3, 11]
+    type: SIMPLE_RAIL
+    tex_extra:
+      powered: [3, 11]
     opacity: 0
 
   - id: 30
@@ -406,6 +463,9 @@ blocks:
       4: 
         tex: [7, 0]
         name: Double Brick Slab
+      5:
+        tex: [6, 3]
+        name: Double Stone Brick Slab
 
   - id: 44
     idStr: SLAB
@@ -437,6 +497,9 @@ blocks:
       4: 
         tex: [7, 0]
         name: Brick Slab
+      5:
+        tex: [6, 3]
+        name: Stone Brick Slab
 
   - id: 45
     idStr: BRICK
@@ -611,6 +674,16 @@ blocks:
     tex: [3, 5]
     type: LADDER
     opacity: 0
+    
+  - id: 66
+    idStr: rail
+    name: Rail
+    mapcolor: [150, 134, 102]
+    tex: [0, 8]
+    type: MINECART_TRACKS
+    tex_extra:
+      curve: [0, 7]
+    opacity: 0
 
   - id: 67
     idStr: COBBLESTONE_STAIRS
@@ -618,6 +691,14 @@ blocks:
     mapcolor: [115, 115, 115]
     tex: [0, 1]
     type: STAIRS
+    
+  - id: 68
+    idStr: sign
+    name: Wall Sign
+    mapcolor: [111, 91, 54]
+    tex: [4, 0]
+    type: WALLSIGN
+    opacity: 0
 
   - id: 71
     idStr: IRON_DOOR
@@ -695,6 +776,25 @@ blocks:
     tex: [4, 0]
     type: FENCE
     opacity: 0
+    
+  - id: 86
+    idStr: pumpkin
+    name: Pumpkin
+    mapcolor: [227, 144, 29]
+    tex: [7, 7]
+    tex_direction:
+      FORWARD: [7, 7]
+      SIDES: [6, 7]
+      BACKWARD: [6, 7]
+      TOP: [6, 6]
+      BOTTOM: [6, 6]
+    tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
+    
+  - id: 87
+    idStr: hellrock
+    name: Netherrack
+    mapcolor: [104, 8, 8]
+    tex: [7, 6]
 
   - id: 89
     idStr: GLOWSTONE
@@ -703,6 +803,33 @@ blocks:
     tex: [9, 6]
     explored: true
     brightness: 15
+    
+  - id: 91
+    idStr: litpumpkin
+    name: Jack-o'-Lantern
+    mapcolor: [249, 255, 58]
+    explored: true
+    tex: [8, 7]
+    tex_direction:
+      FORWARD: [8, 7]
+      SIDES: [6, 7]
+      BACKWARD: [6, 7]
+      TOP: [6, 6]
+      BOTTOM: [6, 6]
+    tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
+    brightness: 15
+    
+  - id: 92
+    idStr: cake
+    name: Cake
+    mapcolor: [234, 233, 235]
+    tex: [9, 7]
+    type: CAKE
+    tex_extra:
+      side_uncut: [10, 7]
+      side_cut: [11, 7]
+      bottom: [12, 7]
+    opacity: 0
 
   - id: 95
     idStr: INVISIBLE_BEDROCK
@@ -721,6 +848,24 @@ blocks:
     name: Stone Bricks
     mapcolor: [120, 120, 120]
     tex: [6, 3]
+    data:
+      0:
+        tex: [6, 3]
+        name: Stone Bricks
+      1:
+        tex: [4, 6]
+        name: Mossy Stone Bricks
+      2:
+        tex: [5, 6]
+        name: Cracked Stone Bricks
+        
+  - id: 101
+    idStr: fenceIron
+    name: Iron Bars
+    mapcolor: [77, 77, 78]
+    tex: [5, 5]
+    type: SOLID_PANE
+    opacity: 0
 
   - id: 102
     idStr: GLASS_PANE
@@ -739,6 +884,16 @@ blocks:
       FORWARD: [8, 8]
       SIDES: [8, 8]
       BACKWARD: [8, 8]
+      
+  - id: 104
+    idStr: pumpkinStem
+    name: Pumpkin Stem
+    mapcolor: [227, 144, 29]
+    tex: [15, 6]
+    type: STEM
+    tex_extra:
+      curve: [15, 7]
+    opacity: 0
 
   - id: 105
     idStr: MELON_STEM
@@ -764,6 +919,161 @@ blocks:
     mapcolor: [170, 86, 62]
     tex: [7, 0]
     type: STAIRS
+    
+  - id: 109
+    idStr: stairsStoneBrickSmooth
+    name: Stone Brick Stairs
+    mapcolor: [120, 120, 120]
+    tex: [6, 3]
+    type: STAIRS
+    
+  - id: 112
+    idStr: netherBrick
+    name: Nether Brick
+    mapcolor: [54, 24, 30]
+    tex: [0, 14]
+    
+  - id: 114
+    idStr: stairsNetherBrick
+    name: Nether Stairs
+    mapcolor: [54, 24, 30]
+    tex: [0, 14]
+    type: STAIRS
+    
+  - id: 125
+    idStr: woodSlab
+    name: Wooden Double Slab
+    aka: Wood Double Step
+    mapcolor: [200, 200, 200]
+    tex: [4, 0]
+    data:
+      0:
+        tex: [4, 0]
+        name: Oak-Wood Double Slab
+      1:
+        tex: [6, 12]
+        name: Spruce-Wood Double Slab
+      2:
+        tex: [6, 13]
+        name: Birch-Wood Double Slab
+      3:
+        tex: [7, 12]
+        name: Jungle-Wood Double Slab
+    
+  - id: 126
+    idStr: woodSlab
+    name: Wooden Slab
+    aka: Wood Half Step
+    mapcolor: [200, 200, 200]
+    tex: [4, 0]
+    data:
+      0:
+        tex: [4, 0]
+        name: Oak-Wood Slab
+      1:
+        tex: [6, 12]
+        name: Spruce-Wood Slab
+      2:
+        tex: [6, 13]
+        name: Birch-Wood Slab
+      3:
+        tex: [7, 12]
+        name: Jungle-Wood Slab
+    type: HALFHEIGHT
+    
+  - id: 128
+    idStr: stairsSandStone
+    name: Sandstone Stairs
+    mapcolor: [157, 128, 79]
+    tex: [0, 12]
+    type: STAIRS
+    
+  - id: 134
+    idStr: stairsWoodSpruce
+    name: Spruce-Wood Stairs
+    mapcolor: [157, 128, 79]
+    tex: [6, 12]
+    type: STAIRS
+
+  - id: 135
+    idStr: stairsWoodBirch
+    name: Birch-Wood Stairs
+    mapcolor: [157, 128, 79]
+    tex: [6, 13]
+    type: STAIRS
+
+  - id: 136
+    idStr: stairsWoodJungle
+    name: Jungle-Wood Stairs
+    mapcolor: [157, 128, 79]
+    tex: [7, 12]
+    type: STAIRS
+    
+  - id: 139
+    idStr: cobbleWall
+    name: Cobblestone Wall
+    mapcolor: [128, 128, 128]
+    tex: [0, 1]
+    type: FENCE
+    data:
+      0:
+        tex: [0, 1]
+        name: Cobblestone Wall
+      1:
+        tex: [4, 2]
+        name: Mossy Cobblestone Wall
+    opacity: 0
+    
+  - id: 141
+    idStr: carrots
+    name: Carrots
+    mapcolor: [200, 100, 100]
+    tex: [11, 12]
+    type: CROPS
+    data:
+      0: {tex: [8, 12]}
+      1: {tex: [9, 12]}
+      2: {tex: [10, 12]}
+      3: {tex: [11, 12]}
+    opacity: 0
+    
+  - id: 142
+    idStr: potatoes
+    name: Potatoes
+    mapcolor: [200, 100, 100]
+    tex: [12, 12]
+    type: CROPS
+    data:
+      0: {tex: [8, 12]}
+      1: {tex: [9, 12]}
+      2: {tex: [10, 12]}
+      3: {tex: [12, 12]}
+    opacity: 0
+    
+  - id: 155
+    idStr: quartzBlock
+    name: Block of Quartz
+    mapcolor: [255, 255, 255]
+    tex: [9, 13]
+
+  - id: 156
+    idStr: stairsQuartz
+    name: Quartz Stairs
+    mapcolor: [255, 255, 255]
+    
+  - id: 170
+    name: Hay Block
+    
+  - id: 171
+    name: Carpet
+    opacity: 0
+    
+  - id: 173
+    idStr: blockcoal
+    name: Block of Coal
+    mapcolor: [100, 100, 100]
+    tex: [12, 13]
+    opacity: 0
 
   - id: 246
     idStr: GLOWING_OBSIDIAN


### PR DESCRIPTION
Based on 0.8.0build2
Might have wrong IdStr, I couldn't find pocket Idstr.
Hope this helps at least a little bit. They added Sideway Logs pls add it.
- List of Blocks added:
  5:0 Oak Wood Planks
  5:1 Spruce Wood Planks
  5:2 Birch Wood Planks
  5:3 Jungle Wood Planks
  17:3 Jungle Wood
  18:7 Jungle Leaves (Decaying)
  19 Sponge
  24:0 Sandstone
  24:1 Creeper Sandstone
  24:2 Smooth Sandstone
  27 Powered Rail (Powered by Default, so I changed Default texture to powered one)
  43:5 Double Stone Brick Slab
  44:5 Stone Brick Slab
  66 Rail
  68 Wall Sign
  86 Pumpkin
  87 Netherrack
  91 Jack-o'-Lantern
  98:0 Stone Brick
  98:1 Mossy
  98:2 Cracked
  101 Iron Bars
  105 Pumpkin Stem
  109 Stone Brick Stairs
  112 Nether Brick
  114 Nether Brick Stairs
  125:0 Oak Double Slab
  125:1 Spruce Double Slab
  125:2 Birch Double Slab
  125:3 Jungle Double Slab
  126:0 Oak Wood Slab
  126:1 Spruce Wood Slab
  126:2 Birch Wood Slab
  126:3 Jungle Wood Slab
  128 Sandstone Stairs
  134 Spruce Wood Stairs
  135 Birch Wood Stairs
  136 Jungle Wood Stairs
  139:0 Cobblestone Wall
  139:1 Mossy
  141 Carrots
  142 Potatoes
  155 Block of Quartz
  156 Quartz Stairs
  170 Hay Block
  171 Carpet
  173 Block of Coal

-----Now I see that GitHub compares it... T.T Why did I write this......
