### PR TITLE
Minecraft.yml 1.8 general fixes

### DIFF
--- a/minecraft.yaml
+++ b/minecraft.yaml
@@ -158,8 +158,7 @@
 #
 #         "FLOOR" is currently used for redstone wire and Water Lilies
 #
-#         "THINSLICE" is currently only used for snow, and I may eventually
-#         change that to "SNOW" instead, and clean up that rendering.
+#         "THINSLICE" is currently used for snow and carpet. Rendering may need cleaning up.
 #
 #   tex_extra: This is a section to provide extra texture information for
 #         block types which require it.  A list of the required tex_extra
@@ -281,7 +280,7 @@ blocks:
         name: Andesite
         tex: [8, 16]
       6:
-        name: Polished Andisite
+        name: Polished Andesite
         tex: [9, 16]
         
   - id: 2
@@ -385,7 +384,7 @@ blocks:
 
   - id: 8
     idStr: flowing_water
-    name: Water (Active)
+    name: Water (Flowing)
     mapcolor: [38, 92, 255]
     type: WATER
     tex: [15, 12]
@@ -401,7 +400,7 @@ blocks:
 
   - id: 10
     idStr: flowing_lava
-    name: Lava (Active)
+    name: Lava (Flowing)
     mapcolor: [255, 90, 0]
     tex: [15, 14]
     type: SEMISOLID
@@ -457,9 +456,6 @@ blocks:
     name: Wood
     mapcolor: [102, 81, 51]
     tex: [4, 1]
-    tex_direction:
-      TOP: [5, 1]
-      BOTTOM: [5, 1]
     data:
       0:
         name: Oak Wood (Upright)
@@ -549,15 +545,16 @@ blocks:
     mapcolor: [60, 192, 41]
     tex: [5, 3] # The "correct" one is actually [4, 3] but with the current
                 # transparency rendering issues, this one looks better.
+    type: GLASS
     opacity: 1
     data:
       0:
-        name: Leaves
+        name: Oak Leaves
         mapcolor: [60, 192, 41]
         tex: [5, 3]
       1:
-        name: Pine Leaves
-        aka: Spruce Leaves
+        name: Spruce Leaves
+        aka: Pine Leaves
         mapcolor: [74, 131, 66]
         tex: [5, 8]
       2:
@@ -570,30 +567,30 @@ blocks:
         tex: [5, 12]
 
       4: # bit 0x4 - "Permanent"
-        name: Leaves (Permanent)
+        name: Oak Leaves (Permanent)
         mapcolor: [60, 192, 41]
         tex: [5, 3]
       5:
-        name: Pine Leaves (Permanent)
-        aka: Spruce Leaves
+        name: Spruce Leaves (No Decay)
+        aka: Pine Leaves (No Decay)
         mapcolor: [74, 131, 66]
         tex: [5, 8]
       6:
-        name: Birch Leaves (Permanent)
+        name: Birch Leaves (No Decay)
         mapcolor: [89, 151, 76]
         tex: [5, 3]
       7:
-        name: Jungle Leaves (Permanent)
+        name: Jungle Leaves (No Decay)
         mapcolor: [74, 131, 66]
         tex: [5, 12]
 
       8: # bit 0x8 - "Decaying"
-        name: Leaves (Decaying)
+        name: Oak Leaves (Decaying)
         mapcolor: [60, 192, 41]
         tex: [5, 3]
       9:
-        name: Pine Leaves (Decaying)
-        aka: Spruce Leaves
+        name: Spruce Leaves (Decaying)
+        aka: Pine Leaves (Decaying)
         mapcolor: [74, 131, 66]
         tex: [5, 8]
       10:
@@ -636,11 +633,9 @@ blocks:
     idStr: dispenser
     name: Dispenser
     mapcolor: [96, 96, 96]
-    tex: [14, 2]
+    tex: [13, 2]
     tex_direction:
       FORWARD: [14, 2]
-      SIDES: [13, 2]
-      BACKWARD: [13, 2]
       TOP: [14, 3]
       BOTTOM: [14, 3]
     tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
@@ -989,16 +984,13 @@ blocks:
     aka: Half Step
     mapcolor: [200, 200, 200]
     tex: [6, 0]
+    type: HALFHEIGHT
     data:
       0:
-        tex: [6, 0]
+        tex: [5, 0]
         tex_direction:
           TOP: [6, 0]
           BOTTOM: [6, 0]
-          FORWARD: [5, 0]
-          BACKWARD: [5, 0]
-          SIDES: [5, 0]
-        type: HALFHEIGHT
         name: Stone Slab
       1:
         tex: [0, 12]
@@ -1036,10 +1028,18 @@ blocks:
     name: TNT
     mapcolor: [160, 83, 65]
     tex: [8, 0]
-    tex_direction:
-      TOP: [9, 0]
-      BOTTOM: [10, 0]
-
+    data:
+      0:
+        name: TNT
+        tex_direction:
+          TOP: [9, 0]
+          BOTTOM: [10, 0]
+      1:
+        name: TNT (Primed)
+        tex: [16, 16]
+        tex_direction:
+          TOP: [17, 16]
+          BOTTOM: [18, 16]
   - id: 47
     idStr: bookshelf
     name: Bookshelf
@@ -1476,74 +1476,74 @@ blocks:
     brightness: 9
 
   - id: 95
-    name: Stained Glass #Broken Transparency causing these blocks to look like stained clay
-    tex: [0, 17]
-    opacity: 0
-    type: GLASS
+    name: Stained Glass #Broken Transparency, added temporary texture until it is fixed.
+    tex: [0, 19]
     data:
       0:
         name: White Stained Glass
         mapcolor: [222, 222, 222]
       1:
-        tex: [1, 17]
+        tex: [1, 19]
         name: Orange Stained Glass
         mapcolor: [234, 127, 55]
       2:
-        tex: [2, 17]
+        tex: [2, 19]
         name: Magenta Stained Glass
         mapcolor: [191, 75, 201]
       3:
-        tex: [3, 17]
+        tex: [3, 19]
         name: Light Blue Stained Glass
         mapcolor: [104, 139, 212]
       4:
-        tex: [4, 17]
+        tex: [4, 19]
         name: Yellow Stained Glass
         mapcolor: [104, 139, 212]
       5:
-        tex: [5, 17]
+        tex: [5, 19]
         name: Lime Stained Glass
         mapcolor: [59, 189, 48]
       6:
-        tex: [6, 17]
+        tex: [6, 19]
         name: Pink Stained Glass
         mapcolor: [217, 131, 155]
       7:
-        tex: [7, 17]
+        tex: [7, 19]
         name: Gray Stained Glass
         mapcolor: [66, 66, 66]
       8:
-        tex: [8, 17]
+        tex: [8, 19]
         name: Light Grey Stained Glass
         mapcolor: [166, 166, 166]
       9:
-        tex: [9, 17]
+        tex: [9, 19]
         name: Cyan Stained Glass
         mapcolor: [39, 117, 149]
       10:
-        tex: [10, 17]
+        tex: [10, 19]
         name: Purple Stained Glass
         mapcolor: [129, 54, 196]
       11:
-        tex: [11, 17]
+        tex: [11, 19]
         name: Blue Stained Glass
         mapcolor: [39, 51, 161]
       12:
-        tex: [12, 17]
+        tex: [12, 19]
         name: Brown Stained Glass
         mapcolor: [86, 51, 28]
       13:
-        tex: [13, 17]
+        tex: [13, 19]
         name: Green Stained Glass
         mapcolor: [56, 77, 24]
       14:
-        tex: [14, 17]
+        tex: [14, 19]
         name: Red Stained Glass
         mapcolor: [164, 45, 41]
       15:
-        tex: [15, 17]
+        tex: [15, 19]
         name: Black Stained Glass
         mapcolor: [0, 0, 0]
+    type: GLASS
+    opacity: 0
 
   - id: 96
     idStr: trapdoor
@@ -1746,12 +1746,13 @@ blocks:
     name: Enchantment Table
     aka: Enchanting Table
     mapcolor: [88, 23, 22]
-    tex: [6, 10]
-    type: ENCHANTMENT_TABLE
+    tex: [6, 11]
+    type: ENCHANTMENT_TABLE #<-currently does nothing. Fix if possible.
     opacity: 0
-    tex_extra:
-      sides: [6, 11]
-      bottom: [7, 11]
+    tex_direction:
+      TOP: [6, 10]
+      BOTTOM: [7, 11]
+    
 
   - id: 117
     idStr: brewing_stand
@@ -2251,73 +2252,72 @@ blocks:
     idStr: stained_glass_pane
     name: Stained Glass Pane
     mapcolor: [255, 255, 255]
-    tex: [1, 3]
-    type: GLASS
+    tex: [0, 19]
+    type: SOLID_PANE
     data:
       0:
         name: White Stained Glass Pane
         mapcolor: [222, 222, 222]
       1:
-        tex: [1, 17]
+        tex: [1, 19]
         name: Orange Stained Glass Pane
         mapcolor: [234, 127, 55]
       2:
-        tex: [2, 17]
+        tex: [2, 19]
         name: Magenta Stained Glass Pane
         mapcolor: [191, 75, 201]
       3:
-        tex: [3, 17]
+        tex: [3, 19]
         name: Light Blue Stained Glass Pane
         mapcolor: [104, 139, 212]
       4:
-        tex: [4, 17]
+        tex: [4, 19]
         name: Yellow Stained Glass Pane
         mapcolor: [104, 139, 212]
       5:
-        tex: [5, 17]
+        tex: [5, 19]
         name: Lime Stained Glass Pane
         mapcolor: [59, 189, 48]
       6:
-        tex: [6, 17]
+        tex: [6, 19]
         name: Pink Stained Glass Pane
         mapcolor: [217, 131, 155]
       7:
-        tex: [7, 17]
+        tex: [7, 19]
         name: Gray Stained Glass Pane
         mapcolor: [66, 66, 66]
       8:
-        tex: [8, 17]
+        tex: [8, 19]
         name: Light Grey Stained Glass Pane
         mapcolor: [166, 166, 166]
       9:
-        tex: [9, 17]
+        tex: [9, 19]
         name: Cyan Stained Glass Pane
         mapcolor: [39, 117, 149]
       10:
-        tex: [10, 17]
+        tex: [10, 19]
         name: Purple Stained Glass Pane
         mapcolor: [129, 54, 196]
       11:
-        tex: [11, 17]
+        tex: [11, 19]
         name: Blue Stained Glass Pane
         mapcolor: [39, 51, 161]
       12:
-        tex: [12, 17]
+        tex: [12, 19]
         name: Brown Stained Glass Pane
         mapcolor: [86, 51, 28]
       13:
-        tex: [13, 17]
+        tex: [13, 19]
         name: Green Stained Glass Pane
         mapcolor: [56, 77, 24]
       14:
-        tex: [14, 17]
+        tex: [14, 19]
         name: Red Stained Glass Pane
         mapcolor: [164, 45, 41]
       15:
-        tex: [15, 17]
+        tex: [15, 19]
         name: Black Stained Glass Pane
         mapcolor: [0, 0, 0]
-    type: SOLID_PANE
     opacity: 0
 
   - id: 161
@@ -2446,7 +2446,7 @@ blocks:
     idStr: acacia_stairs
     name: Acacia Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [15, 0]
+    tex: [0, 15]
     type: STAIRS
 
   - id: 164
@@ -2459,6 +2459,8 @@ blocks:
   - id: 165
     idStr: slime
     name: Slime Block
+    type: SEMISOLID
+    tex: [17, 15]
     
   - id: 166
     idStr: barrier
@@ -2601,11 +2603,20 @@ blocks:
       5:
         name: Peony Stem
         tex: [16, 14]
+#tall plant tops are dynamically changed ingame, but use multiple IDs for some reason.
       8:
+        name: Tall Plant Top 
+        tex: [5, 3]
+      9:
         name: Tall Plant Top
-        tex: [5, 4]
+        tex: [5, 3]
+      10:
+        name: Tall Plant Top
+        tex: [5, 3]
       11:
-        name: Tall Plant Top (Alt)
-        tex: [5, 4]
-      
+        name: Tall Plant Top
+        tex: [5, 3]
+      12:
+        name: Tall Plant Top
+        tex: [5, 3]
       


### PR DESCRIPTION
Fixed typos and a few redundant lines, added Primed TNT and slime block texture, and fixed some incorrect textures. Also if anyone could fix block rotation for ladders/vines/chests, would be great, don't know the code that well. Needs updated terrain.png, see other pull request.
