### PR TITLE
Gave melon slice item a name distinct from the melon block

### DIFF
--- a/items.py
+++ b/items.py
@@ -361,7 +361,7 @@ items_txt = """
  357  Cookie                 items.png  12,5
  358  Map                    items.png  12,3   x1
  359  Shears                 items.png  13,5   +238
- 360  Melon                  items.png  13,6
+ 360  Melon_Slice            items.png  13,6
  361  Pumpkin_Seeds          items.png  13,3
  362  Melon_Seeds            items.png  14,3
  363  Raw_Beef               items.png  9,6

--- a/materials.py
+++ b/materials.py
@@ -167,8 +167,8 @@ class MCMaterials(object):
             self.addYamlBlocks(blockyaml)
 
         except Exception, e:
-            log.warn(u"Exception while loading block info from %s: %s", f, e)
-            traceback.print_exc()
+            log.error(u"Exception while loading block info from %s: %s", f, e)
+            raise
 
     def addYamlBlocks(self, blockyaml):
         self.yamlDatas.append(blockyaml)
@@ -176,9 +176,9 @@ class MCMaterials(object):
             try:
                 self.addYamlBlock(block)
             except Exception, e:
-                log.warn(u"Exception while parsing block: %s", e)
-                traceback.print_exc()
-                log.warn(u"Block definition: \n%s", pformat(block))
+                log.error(u"Exception while parsing block: %s", e)
+                log.error(u"Block definition: \n%s", pformat(block))
+                raise
 
     def addYamlBlock(self, kw):
         blockID = kw['id']

--- a/pocket.yaml
+++ b/pocket.yaml
@@ -18,83 +18,81 @@ blocks:
     idStr: STONE
     name: Stone
     mapcolor: [120, 120, 120]
-    tex: [4, 0]
+    tex: [1, 0]
 
   - id: 2
     idStr: GRASS
     name: Grass
     mapcolor: [117, 176, 73]
-    tex: [3, 0]
+    tex: [0, 0]
     tex_direction:
-      FORWARD: [1, 0]
-      SIDES: [1, 0]
-      BACKWARD: [1, 0]
-      BOTTOM: [21, 0]
+      FORWARD: [3, 0]
+      SIDES: [3, 0]
+      BACKWARD: [3, 0]
+      BOTTOM: [2, 0]
 
   - id: 3
     idStr: DIRT
     name: Dirt
     mapcolor: [134, 96, 67]
-    tex: [21, 0]
+    tex: [2, 0]
 
   - id: 4
     idStr: COBBLESTONE
     name: Cobblestone
     mapcolor: [115, 115, 115]
-    tex: [5, 0]
+    tex: [0, 1]
 
   - id: 5
     idStr: PLANK
     name: Wood Planks
     mapcolor: [157, 128, 79]
-    tex: [22, 0]
+    tex: [4, 0]
     data:
       0:
-        name: Oak Wood Planks
-        aka: Wood Planks
-        tex: [22, 0]
+        name: Wood Planks
+        tex: [4, 0]
       1:
-        name: Spruce Wood Planks
-        tex: [23, 0]
+        name: Wood Planks
+        tex: [6, 12]
       2:
-        name: Birch Wood Planks
-        tex: [24, 0]
+        name: Wood Planks
+        tex: [6, 13]
       3:
-        name: Jungle Wood Planks
-        tex: [25, 0]
+        name: Wood Planks
+        tex: [7, 12]
 
   - id: 6
     idStr: SAPLING
     name: Sapling
     mapcolor: [120, 120, 120]
-    tex: [4, 1]
+    tex: [15, 0]
     type: DECORATION_CROSS
     opacity: 0
     data:
-      0: 
-        name: Oak Sapling
-        aka: Sapling
-        tex: [4, 1]
-      1: 
+      0:
+        name: Sapling
+        tex: [15, 0]
+      1:
         name: Spruce Sapling
-        tex: [6, 1]
-      2: 
+        tex: [15, 3]
+      2:
         name: Birch Sapling
-        tex: [5, 1]
+        tex: [15, 4]
 
   - id: 7
     idStr: BEDROCK
     name: Bedrock
     aka: Adminium
     mapcolor: [84, 84, 84]
-    tex: [11, 0]
+    tex: [1, 1]
 
   - id: 8
     idStr: WATER
     name: Water (active)
     mapcolor: [38, 92, 255]
     type: WATER
-    tex: [22, 7]
+    tex: [15, 12]
     opacity: 3
 
   - id: 9
@@ -102,14 +100,14 @@ blocks:
     name: Water
     mapcolor: [38, 92, 255]
     type: WATER
-    tex: [22, 7]
+    tex: [15, 12]
     opacity: 3
 
   - id: 10
     idStr: LAVA
     name: Lava (active)
     mapcolor: [255, 90, 0]
-    tex: [23, 7]
+    tex: [15, 14]
     type: SEMISOLID
     brightness: 15
 
@@ -117,7 +115,7 @@ blocks:
     idStr: STATIONARY_LAVA
     name: Lava
     mapcolor: [255, 90, 0]
-    tex: [23, 7]
+    tex: [15, 14]
     type: SEMISOLID
     brightness: 15
 
@@ -125,13 +123,13 @@ blocks:
     idStr: SAND
     name: Sand
     mapcolor: [218, 210, 158]
-    tex: [14, 0]
+    tex: [2, 1]
 
   - id: 13
     idStr: GRAVEL
     name: Gravel
     mapcolor: [136, 126, 126]
-    tex: [20, 0]
+    tex: [3, 1]
 
   - id: 14
     idStr: GOLD_ORE
@@ -155,92 +153,24 @@ blocks:
     idStr: WOOD
     name: Wood
     mapcolor: [102, 81, 51]
-    tex: [8, 1]
+    tex: [4, 1]
     tex_direction:
-      TOP: [9, 1]
-      BOTTOM: [9, 1]
+      TOP: [5, 1]
+      BOTTOM: [5, 1]
     data:
       0:
-        name: Oak Wood (Upright)
-        aka: Wood
-        tex: [8, 1]
-        tex_direction:
-          TOP: [9, 1]
-          BOTTOM: [9, 1]
+        name: Wood
+        tex: [4, 1]
       1:
-        name: Spruce Wood (Upright)
-        tex: [12, 1]
-        tex_direction:
-          TOP: [13, 1]
-          BOTTOM: [13, 1]
+        name: Pine Wood
+        aka: Spruce Wood, Redwood
+        tex: [4, 7]
       2:
-        name: Birch Wood (Upright)
-        tex: [10, 1]
-        tex_direction:
-          TOP: [11, 1]
-          BOTTOM: [11, 1]
+        name: Birch Wood
+        tex: [5, 7]
       3:
-        name: Jungle Wood (Upright)
-        tex: [14, 1]
-        tex_direction:
-          TOP: [15, 1]
-          BOTTOM: [15, 1]
-      4:
-        name: Oak Wood (East/West)
-        tex: [8, 1]
-        tex_direction:
-          SIDES: [9, 1]
-      5:
-        name: Spruce Wood (East/West)
-        tex: [12, 1]
-        tex_direction:
-          SIDES: [13, 1]
-      6:
-        name: Birch Wood (East/West)
-        tex: [10, 1]
-        tex_direction:
-          SIDES: [10, 14]
-      7:
-        name: Jungle Wood (East/West)
-        tex: [14, 1]
-        tex_direction:
-          SIDES: [15, 1]
-      8:
-        name: Oak Wood (North/South)
-        tex: [8, 1]
-        tex_direction:
-          FORWARD: [9, 1]
-          BACKWARD: [9, 1]
-      9:
-        name: Spruce Wood (North/South)
-        tex: [12, 1]
-        tex_direction:
-          FORWARD: [13, 1]
-          BACKWARD: [13, 1]
-      10:
-        name: Birch Wood (North/South)
-        tex: [10, 1]
-        tex_direction:
-          FORWARD: [11, 1]
-          BACKWARD: [11, 1]
-      11:
-        name: Jungle Wood (North/South)
-        tex: [14, 1]
-        tex_direction:
-          FORWARD: [15, 1]
-          BACKWARD: [15, 1]
-      12:
-        name: Oak Wood (Bark Only)
-        tex: [8, 1]
-      13:
-        name: Spruce Wood (Bark Only)
-        tex: [12, 1]
-      14:
-        name: Birch Wood (Bark Only)
-        tex: [10, 1]
-      15:
-        name: Jungle Wood (Bark Only)
-        tex: [14, 1]
+        name: Jungle Wood
+        tex: [9, 9]
 
   - id: 18
     idStr: LEAVES
@@ -253,68 +183,67 @@ blocks:
       0:
         name: Leaves
         mapcolor: [60, 192, 41]
-        tex: [2, 3]
+        tex: [5, 3]
       1:
         name: Pine Leaves
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [3, 3]
+        tex: [5, 8]
       2:
         name: Birch Leaves
         mapcolor: [89, 151, 76]
-        tex: [4, 3]
+        tex: [5, 3]
       3:
         name: Jungle Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 3]
+        tex: [5, 12]
 
       4: # bit 0x4 - "Decaying"
         name: Leaves (Decaying)
         mapcolor: [60, 192, 41]
-        tex: [2, 3]
+        tex: [5, 3]
       5:
         name: Pine Leaves (Decaying)
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [3, 3]
+        tex: [5, 8]
       6:
         name: Birch Leaves (Decaying)
         mapcolor: [89, 151, 76]
-        tex: [4, 3]
+        tex: [5, 3]
       7:
         name: Jungle Leaves (Decaying)
         mapcolor: [74, 131, 66]
-        tex: [5, 3]
-
-      8: # bit 0x8 - "Permanent"
+        tex: [5, 12]
+      4: # bit 0x8 - "Permanent"
         name: Leaves (Permanent)
         mapcolor: [60, 192, 41]
-        tex: [2, 3]
-      9:
+        tex: [5, 3]
+      5:
         name: Pine Leaves (Permanent)
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [3, 3]
-      10:
+        tex: [5, 8]
+      6:
         name: Birch Leaves (Permanent)
         mapcolor: [89, 151, 76]
-        tex: [4, 3]
-      11:
+        tex: [5, 3]
+      7:
         name: Jungle Leaves (Permanent)
         mapcolor: [74, 131, 66]
-        tex: [5, 3]
+        tex: [5, 12]
 
   - id: 19
     idStr: sponge
     name: Sponge
     mapcolor: [193, 193, 57]
-    tex: [24, 2]
+    tex: [0, 3]
 
   - id: 20
     idStr: GLASS
     name: Glass
     mapcolor: [255, 255, 255]
-    tex: [25, 2]
+    tex: [1, 3]
     type: GLASS
     opacity: 0
 
@@ -322,71 +251,73 @@ blocks:
     idStr: LAPIS_LAZULI_ORE
     name: Lapis Lazuli Ore
     mapcolor: [27, 70, 161]
-    tex: [3, 2]
+    tex: [0, 10]
 
   - id: 22
     idStr: LAPIS_LAZULI_BLOCK
     name: Lapis Lazuli Block
     mapcolor: [0, 0, 0]
-    tex: [20 ,1]
+    tex: [0, 9]
 
   - id: 24
     idStr: SANDSTONE
     name: Sandstone
     mapcolor: [218, 210, 158]
-    tex: [15, 0]
+    tex: [0, 12]
     tex_direction:
-      TOP: [18, 0]
-      BOTTOM: [19, 0]
+      TOP: [0, 11]
+      BOTTOM: [0, 13]
     data:
       0:
         name: Sandstone
         mapcolor: [218, 210, 158]
-        tex: [15, 0]
+        tex: [0, 12]
       1:
         name: Sandstone
         aka: Decorative Sandstone
         mapcolor: [218, 210, 158]
-        tex: [16, 0]
+        tex: [5, 14]
         tex_direction:
-          TOP: [18, 0]
-          BOTTOM: [19, 0]
+          TOP: [0, 11]
+          BOTTOM: [0, 11]
       2:
         name: Sandstone
         aka: Smooth Sandstone
         mapcolor: [218, 210, 158]
-        tex: [17, 0]
+        tex: [6, 14]
         tex_direction:
-          TOP: [18, 0]
-          BOTTOM: [19, 0]
+          TOP: [0, 11]
+          BOTTOM: [0, 11]
 
   - id: 26
     idStr: BED
     name: Bed
     mapcolor: [255, 0, 0]
-    tex: [8. 5]
+    tex: [7, 8]
     type: BED
     tex_extra:
-      foot_top: [5, 5]
-      head_side: [10, 5]
-      foot_side: [7, 5]
-      foot: [6, 5]
-      head: [9, 5]
+      foot_top: [6, 8]
+      head_side: [7, 9]
+      foot_side: [6, 9]
+      foot: [5, 9]
+      head: [8, 9]
     opacity: 0
 
   - id: 27
     idStr: goldenRail
     name: Powered Rail
     mapcolor: [120, 53, 28]
-    tex: [0, 5]
+    tex: [3, 11]
     type: SIMPLE_RAIL
+    tex_extra:
+      powered: [3, 11]
     opacity: 0
 
   - id: 30
     idStr: WEB
     name: Web
     mapcolor: [255, 255, 255]
-    tex: [1, 1]
+    tex: [11, 0]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -397,13 +328,13 @@ blocks:
     tex: [7, 2]
     data:
       0:
-        tex: [11, 2]
-        name: Tall Grass
+        tex: [7, 3]
+        name: (Unused Shrub)
       1:
-        tex: [11, 2]
+        tex: [7, 2]
         name: Tall Grass
       2:
-        tex: [12, 2]
+        tex: [8, 3]
         name: Fern
     type: DECORATION_CROSS
     opacity: 0
@@ -412,7 +343,7 @@ blocks:
     idStr: deadbush
     name: Dead Shrub
     mapcolor: [148, 100, 40]
-    tex: [9, 2]
+    tex: [7, 3]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -420,72 +351,72 @@ blocks:
     idStr: WOOL
     name: White Wool
     mapcolor: [222, 222, 222]
-    tex: [24, 7]
+    tex: [0, 4]
     data:
-      0: 
-        tex: [24, 7]
+      0:
+        tex: [0, 4]
         name: White Wool
         mapcolor: [222, 222, 222]
-      1: 
-        tex: [25, 7]
+      1:
+        tex: [2, 13]
         name: Orange Wool
         mapcolor: [234, 127, 55]
-      2: 
-        tex: [26, 7]
+      2:
+        tex: [2, 12]
         name: Magenta Wool
         mapcolor: [191, 75, 201]
-      3: 
-        tex: [27, 7]
+      3:
+        tex: [2, 11]
         name: Light Blue Wool
         aka: Aqua Wool
         mapcolor: [104, 139, 212]
-      4: 
-        tex: [28, 7]
+      4:
+        tex: [2, 10]
         name: Yellow Wool
         mapcolor: [104, 139, 212]
-      5: 
-        tex: [29, 7]
+      5:
+        tex: [2, 9]
         name: Lime Wool
         mapcolor: [59, 189, 48]
-      6: 
-        tex: [30, 7]
+      6:
+        tex: [2, 8]
         name: Pink Wool
         mapcolor: [217, 131, 155]
-      7: 
-        tex: [31, 7]
+      7:
+        tex: [2, 7]
         name: Gray Wool
         mapcolor: [66, 66, 66]
-      8: 
-        tex: [0, 8]
+      8:
+        tex: [1, 14]
         name: Light Gray Wool
         mapcolor: [166, 166, 166]
-      9: 
-        tex: [1, 8]
+      9:
+        tex: [1, 13]
         name: Cyan Wool
         mapcolor: [39, 117, 149]
-      10: 
-        tex: [2, 8]
+      10:
+        tex: [1, 12]
         name: Purple Wool
         aka: Indigo Wool, Violet Wool
         mapcolor: [129, 54, 196]
-      11: 
-        tex: [3, 8]
+      11:
+        tex: [1, 11]
         name: Blue Wool
         mapcolor: [39, 51, 161]
-      12: 
-        tex: [4, 8]
+      12:
+        tex: [1, 10]
         name: Brown Wool
         mapcolor: [86, 51, 28]
-      13: 
-        tex: [5, 8]
+      13:
+        tex: [1, 9]
         name: Green Wool
         mapcolor: [56, 77, 24]
-      14: 
-        tex: [6, 8]
+      14:
+        tex: [1, 8]
         name: Red Wool
         mapcolor: [164, 45, 41]
-      15: 
-        tex: [7, 8]
+      15:
+        tex: [1, 7]
         name: Black Wool
         mapcolor: [0, 0, 0]
 
@@ -493,14 +424,14 @@ blocks:
     idStr: YELLOW_FLOWER
     name: Flower
     mapcolor: [255, 255, 0]
-    tex: [3, 1]
+    tex: [13, 0]
     type: DECORATION_CROSS
     opacity: 0
 
   - id: 38
-    name: Poppy
+    name: Rose
     mapcolor: [255, 0, 0]
-    tex: [2, 1]
+    tex: [12, 0]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -508,7 +439,7 @@ blocks:
     idStr: BROWN_MUSHROOM
     name: Brown Mushroom
     mapcolor: [145, 109, 85]
-    tex: [31, 1]
+    tex: [13, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -516,7 +447,7 @@ blocks:
     idStr: RED_MUSHROOM
     name: Red Mushroom
     mapcolor: [226, 18, 18]
-    tex: [30, 1]
+    tex: [12, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -524,136 +455,134 @@ blocks:
     idStr: GOLD_BLOCK
     name: Block of Gold
     mapcolor: [231, 165, 45]
-    tex: [17, 1]
+    tex: [7, 1]
 
   - id: 42
     idStr: IRON_BLOCK
     name: Block of Iron
     mapcolor: [191, 191, 191]
-    tex: [16, 1]
+    tex: [6, 1]
 
   - id: 43
     idStr: DOUBLE_SLAB
-    name: Stone Slab (Double)
+    name: Double Stone Slab
     aka: Step
     mapcolor: [200, 200, 200]
-    tex: [27, 0]
+    tex: [5, 0]
+    tex_direction:
+      TOP: [6, 0]
+      BOTTOM: [6, 0]
+      FORWARD: [5, 0]
+      BACKWARD: [5, 0]
+      SIDES: [5, 0]
+
     data:
-      0: 
-        name: Double Stone Slab
-        tex: [27, 0]
-        tex_direction:
-          TOP: [26, 0]
-          BOTTOM: [26, 0]
-      1: 
-        name: Double Sandstone Slab
-        tex: [15, 0]
-        tex_direction:
-          TOP: [0, 18]
-          BOTTOM: [0, 19]
-      2: 
-        name: Double Wooden Slab (Old)
-        tex: [22, 0]
-      3: 
-        name: Double Cobblestone Slab
+      0:
         tex: [5, 0]
-      4: 
-        name: Double Brick Slab
-        tex: [28, 0]
-      5:
-        name: Double Stone Brick Slab
+        name: Double Stone Slab
+      1:
+        tex: [0, 12]
+        name: Double Sandstone Slab
+      2:
+        tex: [4, 0]
+        name: Double Wooden Slab
+      3:
+        tex: [0, 1]
+        name: Double Cobblestone Slab
+      4:
         tex: [7, 0]
+        name: Double Brick Slab
+      5:
+        tex: [6, 3]
+        name: Double Stone Brick Slab
       6:
+        tex: [9, 13]
         name: Double Quartz Slab
-        tex: [25, 1]
       7:
+        tex: [9, 13]
         name: Double Solid Stone Slab
-        tex: [26, 0]
 
   - id: 44
     idStr: SLAB
     name: Stone Slab
     aka: Half Step
     mapcolor: [200, 200, 200]
-    tex: [27, 0]
+    tex: [6, 0]
+    tex_direction:
+      TOP: [6, 0]
+      BOTTOM: [6, 0]
+      FORWARD: [5, 0]
+      BACKWARD: [5, 0]
+      SIDES: [5, 0]
     data:
-      0: 
+      0:
+        tex: [6, 0]
         name: Stone Slab
-        tex: [27, 0]
-        tex_direction:
-          TOP: [26, 0]
-          BOTTOM: [26, 0]
-          FORWARD: [27, 0]
-          BACKWARD: [27, 0]
-          SIDES: [27, 0]
-      1: 
+      1:
+        tex: [0, 12]
         name: Sandstone Slab
-        tex: [15, 0]
-        tex_direction:
-          TOP: [0, 18]
-          BOTTOM: [0, 19]
-      2: 
+      2:
+        tex: [4, 0]
         name: Wooden Slab
-        tex: [22, 0]
-      3: 
+      3:
+        tex: [0, 1]
         name: Cobblestone Slab
-        tex: [5, 0]
-      4: 
-        name: Brick Slab
-        tex: [28, 0]
-      5:
-        name: Stone Brick Slab
+      4:
         tex: [7, 0]
+        name: Brick Slab
+      5:
+        tex: [6, 3]
+        name: Stone Brick Slab
       6:
+        tex: [9, 13]
         name: Quartz Slab
-        tex: [25, 1]
       7:
+        tex: [9, 13]
         name: Solid Stone Slab
-        tex: [26, 0]
     type: HALFHEIGHT
 
   - id: 45
     idStr: BRICK
     name: Brick
     mapcolor: [170, 86, 62]
-    tex: [28, 0]
+    tex: [7, 0]
 
   - id: 46
     idStr: TNT
     name: TNT
     mapcolor: [160, 83, 65]
-    tex: [29, 0]
+    tex: [8, 0]
     tex_direction:
-      TOP: [30, 0]
-      BOTTOM: [31, 0]
+      TOP: [9, 0]
+      BOTTOM: [10, 0]
 
   - id: 47
     idStr: BOOKSHELF
     name: Bookshelf
     mapcolor: [188, 152, 98]
-    tex: [0, 1]
+    tex: [3, 2]
     tex_direction:
-      TOP: [22, 0]
-      BOTTOM: [22, 0]
+      TOP: [4, 0]
+      BOTTOM: [4, 0]
 
   - id: 48
     idStr: MOSSY_COBBLESTONE
     name: Moss Stone
     aka: Mossy Cobblestone
     mapcolor: [115, 169, 115]
-    tex: [6, 0]
+    tex: [4, 2]
 
   - id: 49
     idStr: OBSIDIAN
     name: Obsidian
     mapcolor: [26, 11, 43]
-    tex: [12, 0]
+    tex: [5, 2]
 
   - id: 50
     idStr: TORCH
     name: Torch
     mapcolor: [245, 220, 50]
-    tex: [18, 3]
+    tex: [0, 5]
     type: TORCH
     explored: true
     opacity: 0
@@ -664,26 +593,26 @@ blocks:
     name: Fire
     mapcolor: [255, 170, 30]
     type: SEMISOLID
-    tex: [8, 8]
+    tex: [15, 1]
     opacity: 0
     brightness: 15
 
   - id: 53
     idStr: WOODEN_STAIRS
-    name: Oak Wood Stairs
+    name: Wooden Stairs
     mapcolor: [157, 128, 79]
-    tex: [22, 0]
+    tex: [4, 0]
     type: STAIRS
 
   - id: 54
     idStr: CHEST
     name: Chest
     mapcolor: [125, 91, 38]
-    tex: [20, 7]
+    tex: [11, 1]
     type: CHEST
     tex_extra:
-      side_small: [19, 7]
-      top: [18, 7]
+      side_small: [10, 1]
+      top: [9, 1]
       front_big_left: [9, 2]
       front_big_right: [10, 2]
       back_big_left: [9, 3]
@@ -694,85 +623,85 @@ blocks:
     idStr: DIAMOND_ORE
     name: Diamond Ore
     mapcolor: [129, 140, 143]
-    tex: [4, 2]
+    tex: [2, 3]
 
   - id: 57
     idStr: DIAMOND_BLOCK
     name: Block of Diamond
     mapcolor: [45, 166, 152]
-    tex: [18, 1]
+    tex: [8, 1]
 
   - id: 58
     idStr: WORKBENCH
     name: Crafting Table
     mapcolor: [114, 88, 56]
-    tex: [15, 2]
+    tex: [12, 3]
     tex_direction:
-      SIDES: [14, 2]
-      TOP: [13, 2]
-      BOTTOM: [22, 0]
+      SIDES: [11, 3]
+      TOP: [11, 2]
+      BOTTOM: [4, 0]
 
   - id: 59
     idStr: CROPS
-    name: Wheat
+    name: Crops
     aka: Wheat
     mapcolor: [146, 192, 0]
-    tex: [5, 4]
+    tex: [15, 5]
     type: CROPS
     data:
-      0: {tex: [30, 3]}
-      1: {tex: [31, 3]}
-      2: {tex: [0, 4]}
-      3: {tex: [1, 4]}
-      4: {tex: [2, 4]}
-      5: {tex: [3, 4]}
-      6: {tex: [4, 4]}
-      7: {tex: [5, 4]}
+      0: {tex: [8, 5]}
+      1: {tex: [9, 5]}
+      2: {tex: [10, 5]}
+      3: {tex: [11, 5]}
+      4: {tex: [12, 5]}
+      5: {tex: [13, 5]}
+      6: {tex: [14, 5]}
+      7: {tex: [15, 5]}
     opacity: 0
 
   - id: 60
     idStr: FARMLAND
     name: Farmland
     mapcolor: [95, 58, 30]
-    tex: [29, 3]
+    tex: [6, 5]
     tex_direction:
-      FORWARD: [21, 0]
-      SIDES: [21, 0]
-      BACKWARD: [21, 0]
-      BOTTOM: [21, 0]
+      FORWARD: [2, 0]
+      SIDES: [2, 0]
+      BACKWARD: [2, 0]
+      BOTTOM: [2, 0]
 
   - id: 61
     idStr: FURNACE
     name: Furnace
     mapcolor: [96, 96, 96]
-    tex: [16, 2]
+    tex: [12, 2]
     tex_direction:
-      FORWARD: [16, 0]
-      SIDES: [18, 0]
-      BACKWARD: [18, 0]
-      TOP: [19, 0]
-      BOTTOM: [19, 0]
+      FORWARD: [12, 2]
+      SIDES: [13, 2]
+      BACKWARD: [13, 2]
+      TOP: [14, 3]
+      BOTTOM: [14, 3]
     tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
 
   - id: 62
     idStr: BURNING_FURNACE
-    name: Lit Furnace
+    name: Burning Furnace
     mapcolor: [96, 96, 96]
-    tex: [17, 2]
+    tex: [13, 3]
     tex_direction:
-      FORWARD: [16, 0]
-      SIDES: [18, 0]
-      BACKWARD: [18, 0]
-      TOP: [19, 0]
-      BOTTOM: [19, 0]
+      FORWARD: [13, 3]
+      SIDES: [13, 2]
+      BACKWARD: [13, 2]
+      TOP: [14, 3]
+      BOTTOM: [14, 3]
     tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
     brightness: 14
-    
+
   - id: 63
     idStr: sign
-    name: Sign Post
+    name: Sign
     mapcolor: [111, 91, 54]
-    tex: [22, 0]
+    tex: [4, 0]
     type: SIGNPOST
     opacity: 0
 
@@ -780,43 +709,42 @@ blocks:
     idStr: WOODEN_DOOR
     name: Wooden Door
     mapcolor: [136, 109, 67]
-    tex: [22, 3]
+    tex: [1, 5]
     type: DOOR
     tex_extra:
-      bottom: [21, 3]
+      bottom: [1, 6]
     opacity: 0
 
   - id: 65
     idStr: LADDER
     name: Ladder
     mapcolor: [181, 140, 64]
-    tex: [25, 3]
+    tex: [3, 5]
     type: LADDER
     opacity: 0
-    
+
   - id: 66
     idStr: rail
     name: Rail
-    aka: Minecart Track
     mapcolor: [150, 134, 102]
-    tex: [29, 4]
+    tex: [0, 8]
     type: MINECART_TRACKS
     tex_extra:
-      curve: [20, 4]
+      curve: [0, 7]
     opacity: 0
 
   - id: 67
     idStr: COBBLESTONE_STAIRS
-    name: Cobblestone Stairs
+    name: Stone Stairs
     mapcolor: [115, 115, 115]
-    tex: [5, 0]
+    tex: [0, 1]
     type: STAIRS
-    
+
   - id: 68
     idStr: sign
     name: Wall Sign
     mapcolor: [111, 91, 54]
-    tex: [22, 0]
+    tex: [4, 0]
     type: WALLSIGN
     opacity: 0
 
@@ -824,30 +752,30 @@ blocks:
     idStr: IRON_DOOR
     name: Iron Door
     mapcolor: [191, 191, 191]
-    tex: [24, 3]
+    tex: [2, 5]
     type: DOOR
     tex_extra:
-      bottom: [23, 3]
+      bottom: [2, 6]
     opacity: 0
 
   - id: 73
     idStr: REDSTONE_ORE
     name: Redstone Ore
     mapcolor: [131, 107, 107]
-    tex: [5, 2]
+    tex: [3, 3]
 
   - id: 74
     idStr: GLOWING_REDSTONE_ORE
     name: Redstone Ore (Glowing)
     mapcolor: [131, 107, 107]
-    tex: [5, 2]
+    tex: [3, 3]
     brightness: 9
 
   - id: 78
     idStr: SNOW
     name: Snow Layer
     mapcolor: [255, 255, 255]
-    tex: [7, 3]
+    tex: [2, 4]
     type: THINSLICE
     opacity: 0
 
@@ -855,7 +783,7 @@ blocks:
     idStr: ICE
     name: Ice
     mapcolor: [83, 113, 163]
-    tex: [8, 3]
+    tex: [3, 4]
     type: WATER
     opacity: 3
 
@@ -863,29 +791,29 @@ blocks:
     idStr: SNOW_BLOCK
     name: Snow
     mapcolor: [250, 250, 250]
-    tex: [7, 3]
+    tex: [2, 4]
 
   - id: 81
     idStr: CACTUS
     name: Cactus
     mapcolor: [25, 120, 25]
-    tex: [10, 3]
+    tex: [6, 4]
     tex_direction:
-      TOP: [9, 3]
-      BOTTOM: [11, 3]
+      TOP: [5, 4]
+      BOTTOM: [5, 4]
     opacity: 0
 
   - id: 82
     idStr: CLAY
     name: Clay
     mapcolor: [151, 157, 169]
-    tex: [13, 0]
+    tex: [8, 4]
 
   - id: 83
     idStr: SUGARCANE
     name: Sugar Cane
     mapcolor: [100, 67, 50]
-    tex: [12, 3]
+    tex: [9, 4]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -893,7 +821,7 @@ blocks:
     idStr: FENCE
     name: Fence
     mapcolor: [157, 128, 79]
-    tex: [22, 0]
+    tex: [4, 0]
     type: FENCE
     opacity: 0
 
@@ -901,26 +829,26 @@ blocks:
     idStr: pumpkin
     name: Pumpkin
     mapcolor: [227, 144, 29]
-    tex: [9, 4]
+    tex: [7, 7]
     tex_direction:
-      FORWARD: [9, 4]
-      SIDES: [8, 4]
-      BACKWARD: [8, 4]
-      TOP: [7, 4]
-      BOTTOM: [7, 4]
+      FORWARD: [7, 7]
+      SIDES: [6, 7]
+      BACKWARD: [6, 7]
+      TOP: [6, 6]
+      BOTTOM: [6, 6]
     tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
 
   - id: 87
     idStr: hellrock
     name: Netherrack
     mapcolor: [104, 8, 8]
-    tex: [11, 4]
+    tex: [7, 6]
 
   - id: 89
     idStr: GLOWSTONE
     name: Glowstone
     mapcolor: [249, 212, 156]
-    tex: [17, 4]
+    tex: [9, 6]
     explored: true
     brightness: 15
 
@@ -929,13 +857,13 @@ blocks:
     name: Jack-o'-Lantern
     mapcolor: [249, 255, 58]
     explored: true
-    tex: [10, 4]
+    tex: [8, 7]
     tex_direction:
-      FORWARD: [9, 4]
-      SIDES: [8, 4]
-      BACKWARD: [8, 4]
-      TOP: [7, 4]
-      BOTTOM: [7, 4]
+      FORWARD: [8, 7]
+      SIDES: [6, 7]
+      BACKWARD: [6, 7]
+      TOP: [6, 6]
+      BOTTOM: [6, 6]
     tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
     brightness: 15
 
@@ -943,12 +871,12 @@ blocks:
     idStr: cake
     name: Cake
     mapcolor: [234, 233, 235]
-    tex: [19, 5]
+    tex: [9, 7]
     type: CAKE
     tex_extra:
-      side_uncut: [20 ,5]
-      side_cut: [18, 5]
-      bottom: [17, 5]
+      side_uncut: [10, 7]
+      side_cut: [11, 7]
+      bottom: [12, 7]
     opacity: 0
 
   - id: 95
@@ -959,7 +887,7 @@ blocks:
     idStr: TRAPDOOR
     name: Trapdoor
     mapcolor: [143, 107, 53]
-    tex: [26, 3]
+    tex: [4, 5]
     type: TRAPDOOR
     opacity: 0
 
@@ -967,26 +895,26 @@ blocks:
     idStr: STONE_BRICK
     name: Stone Bricks
     mapcolor: [120, 120, 120]
-    tex: [7, 0]
+    tex: [6, 3]
     data:
       0:
+        tex: [6, 3]
         name: Stone Bricks
-        tex: [7, 0]
       1:
+        tex: [4, 6]
         name: Mossy Stone Bricks
-        tex: [8, 0]
       2:
+        tex: [5, 6]
         name: Cracked Stone Bricks
-        tex: [9, 0]
       3:
+        tex: [5, 13]
         name: Circle Stone Bricks
-        tex: [10, 0]
 
   - id: 101
     idStr: fenceIron
     name: Iron Bars
     mapcolor: [77, 77, 78]
-    tex: [27, 3]
+    tex: [5, 5]
     type: SOLID_PANE
     opacity: 0
 
@@ -994,7 +922,7 @@ blocks:
     idStr: GLASS_PANE
     name: Glass Pane
     mapcolor: [255, 255, 255]
-    tex: [25, 2]
+    tex: [1, 3]
     type: SOLID_PANE
     opacity: 0
 
@@ -1002,36 +930,37 @@ blocks:
     idStr: MELON
     name: Watermelon
     mapcolor: [190, 184, 41]
-    tex: [23, 4]
+    tex: [9, 8]
     tex_direction:
-      TOP: [24, 4]
-      BOTTOM: [24, 4]
+      FORWARD: [8, 8]
+      SIDES: [8, 8]
+      BACKWARD: [8, 8]
 
   - id: 104
     idStr: pumpkinStem
     name: Pumpkin Stem
     mapcolor: [227, 144, 29]
-    tex: [27, 4]
+    tex: [15, 6]
     type: STEM
     tex_extra:
-      curve: [28, 4]
+      curve: [15, 7]
     opacity: 0
 
   - id: 105
     idStr: MELON_STEM
     name: Melon Stem
     mapcolor: [190, 184, 41]
-    tex: [25, 4]
+    tex: [15, 6]
     type: STEM
     tex_extra:
-      curve: [26, 4]
+      curve: [15, 7]
     opacity: 0
 
   - id: 107
     idStr: FENCE_GATE
     name: Fence Gate
     mapcolor: [157, 128, 79]
-    tex: [22, 0]
+    tex: [4, 0]
     type: FENCE_GATE
     opacity: 0
 
@@ -1039,124 +968,109 @@ blocks:
     idStr: BRICK_STAIRS
     name: Brick Stairs
     mapcolor: [170, 86, 62]
-    tex: [28, 0]
+    tex: [7, 0]
     type: STAIRS
-    
+
   - id: 109
     idStr: stairsStoneBrickSmooth
     name: Stone Brick Stairs
     mapcolor: [120, 120, 120]
-    tex: [7, 0]
+    tex: [6, 3]
     type: STAIRS
 
   - id: 112
     idStr: netherBrick
     name: Nether Brick
     mapcolor: [54, 24, 30]
-    tex: [12, 4]
-    
+    tex: [0, 14]
+
   - id: 114
     idStr: stairsNetherBrick
-    name: Nether Brick Stairs
+    name: Nether Stairs
     mapcolor: [54, 24, 30]
-    tex: [12, 4]
+    tex: [0, 14]
     type: STAIRS
 
   - id: 128
     idStr: stairsSandStone
     name: Sandstone Stairs
     mapcolor: [157, 128, 79]
-    tex: [15, 0]
+    tex: [0, 12]
     type: STAIRS
 
   - id: 134
     idStr: stairsWoodSpruce
-    name: Spruce Wood Stairs
+    name: Spruce-Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [23, 0]
+    tex: [6, 12]
     type: STAIRS
 
   - id: 135
     idStr: stairsWoodBirch
-    name: Birch Wood Stairs
+    name: Birch-Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [24, 0]
+    tex: [6, 13]
     type: STAIRS
 
   - id: 136
     idStr: stairsWoodJungle
-    name: Jungle Wood Stairs
+    name: Jungle-Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [25, 0]
+    tex: [7, 12]
     type: STAIRS
 
   - id: 139
     idStr: cobbleWall
     name: Cobblestone Wall
     mapcolor: [128, 128, 128]
-    tex: [5, 0]
+    tex: [0, 1]
     type: FENCE
     data:
       0:
+        tex: [0, 1]
         name: Cobblestone Wall
-        tex: [5, 0]
       1:
+        tex: [4, 2]
         name: Mossy Cobblestone Wall
-        tex: [6, 0]
     opacity: 0
 
   - id: 141
     idStr: carrots
     name: Carrots
     mapcolor: [200, 100, 100]
-    tex: [24, 6]
+    tex: [11, 11]
     type: CROPS
     data:
-      0: {tex: [21, 6]}
-      1: {tex: [22, 6]}
-      2: {tex: [23, 6]}
-      3: {tex: [24, 6]}
+      0: {tex: [8, 11]}
+      1: {tex: [9, 11]}
+      2: {tex: [10, 11]}
+      3: {tex: [11, 11]}
     opacity: 0
 
   - id: 142
     idStr: potatoes
     name: Potatoes
     mapcolor: [200, 100, 100]
-    tex: [28, 6]
+    tex: [12, 11]
     type: CROPS
     data:
-      0: {tex: [25, 6]}
-      1: {tex: [26, 6]}
-      2: {tex: [27, 6]}
-      3: {tex: [28, 6]}
+      0: {tex: [8, 11]}
+      1: {tex: [9, 11]}
+      2: {tex: [10, 11]}
+      3: {tex: [12, 11]}
     opacity: 0
 
   - id: 155
     idStr: quartzBlock
     name: Block of Quartz
     mapcolor: [255, 255, 255]
-    tex: [25, 1]
-    data:
-      0:
-        name: Block of Quartz
-      1:
-        name: Chiseled Quartz Block
-        tex: [1, 28]
-        tex_direction:
-          TOP: [1, 29]
-          BOTTOM: [1, 29]
-      2:
-        name: Pillar Quartz Block
-        tex: [1, 26]
-        tex_direction:
-          TOP: [1, 27]
-          BOTTOM: [1, 27]
+    tex: [9, 13]
 
   - id: 156
     idStr: stairsQuartz
     name: Quartz Stairs
     mapcolor: [255, 255, 255]
-    tex: [25, 1]
+    tex: [9, 13]
     type: STAIRS
 
   - id: 157
@@ -1164,187 +1078,123 @@ blocks:
     name: Wooden Double Slab
     aka: Wood Double Step
     mapcolor: [200, 200, 200]
-    tex: [22, 0]
+    tex: [4, 0]
     data:
       0:
-        name: Double Oak Wood Slab
+        tex: [4, 0]
+        name: Oak-Wood Double Slab
       1:
-        name: Double Spruce Wood Slab
-        tex: [23, 0]
+        tex: [6, 12]
+        name: Spruce-Wood Double Slab
       2:
-        name: Double Birch Wood Slab
-        tex: [24, 0]
+        tex: [6, 13]
+        name: Birch-Wood Double Slab
       3:
-        name: Double Jungle Wood Slab
-        tex: [25, 0]
+        tex: [7, 12]
+        name: Jungle-Wood Double Slab
 
   - id: 158
     idStr: woodSlab
     name: Wooden Slab
     aka: Wood Half Step
     mapcolor: [200, 200, 200]
-    tex: [22, 0]
+    tex: [4, 0]
     data:
       0:
-        name: Oak Wood Slab
+        tex: [4, 0]
+        name: Oak-Wood Slab
       1:
-        name: Spruce Wood Slab
-        tex: [23, 0]
+        tex: [6, 12]
+        name: Spruce-Wood Slab
       2:
-        name: Birch Wood Slab
-        tex: [24, 0]
+        tex: [6, 13]
+        name: Birch-Wood Slab
       3:
-        name: Jungle Wood Slab
-        tex: [25, 0]
+        tex: [7, 12]
+        name: Jungle-Wood Slab
     type: HALFHEIGHT
 
   - id: 170
     name: Hay Block
     mapcolor: [206, 170, 28]
-    tex: [11, 6]
     tex_direction:
-      FORWARD: [12, 6]
-      SIDES: [12, 6]
-      BACKWARD: [12, 6]
+      TOP: [7, 13]
+      FORWARD: [8, 13]
+      SIDES: [8, 13]
+      BACKWARD: [8, 13]
+      BOTTOM: [7, 13]
 
   - id: 171
     name: Carpet
-    tex: [24, 7]
-    data:
-      0: 
-        name: White Carpet
-        tex: [24, 7]
-        mapcolor: [222, 222, 222]
-      1: 
-        name: Orange Carpet
-        tex: [25, 7]
-        mapcolor: [234, 127, 55]
-      2: 
-        name: Magenta Carpet
-        tex: [26, 7]
-        mapcolor: [191, 75, 201]
-      3: 
-        name: Light Blue Carpet
-        tex: [27, 7]
-        mapcolor: [104, 139, 212]
-      4: 
-        name: Yellow Carpet
-        tex: [28, 7]
-        mapcolor: [104, 139, 212]
-      5: 
-        name: Lime Carpet
-        tex: [29, 7]
-        mapcolor: [59, 189, 48]
-      6: 
-        name: Pink Carpet
-        tex: [30, 7]
-        mapcolor: [217, 131, 155]
-      7: 
-        name: Gray Carpet
-        tex: [31, 7]
-        mapcolor: [66, 66, 66]
-      8: 
-        name: Light Gray Carpet
-        tex: [0, 8]
-        mapcolor: [166, 166, 166]
-      9: 
-        name: Cyan Carpet
-        tex: [1, 8]
-        mapcolor: [39, 117, 149]
-      10: 
-        name: Purple Carpet
-        tex: [2, 8]
-        mapcolor: [129, 54, 196]
-      11: 
-        name: Blue Carpet
-        tex: [3, 8]
-        mapcolor: [39, 51, 161]
-      12: 
-        name: Brown Carpet
-        tex: [4, 8]
-        mapcolor: [86, 51, 28]
-      13: 
-        name: Green Carpet
-        tex: [5, 8]
-        mapcolor: [56, 77, 24]
-      14: 
-        name: Red Carpet
-        tex: [6, 8]
-        mapcolor: [164, 45, 41]
-      15: 
-        name: Black Carpet
-        tex: [7, 8]
-        mapcolor: [0, 0, 0]
-    type: THINSLICE
     opacity: 0
 
   - id: 173
     idStr: blockcoal
     name: Block of Coal
     mapcolor: [100, 100, 100]
-    tex: [19, 1]
+    tex: [12, 13]
+    opacity: 0
 
   - id: 245
     idStr: STONECUTTER
     name: Stonecutter
     mapcolor: [96, 96, 96]
-    tex: [22, 2]
-    tex_direction:
-      FORWARD: [20, 2]
-      SIDES: [21, 2]
-      BACKWARD: [20, 2]
-      BOTTOM: [23, 2]
+    tex: [11, 8]
+    opacity: 0
 
   - id: 246
     idStr: GLOWING_OBSIDIAN
     name: Glowing Obsidian
     mapcolor: [155, 0, 0]
-    tex: [7, 7]
+    tex: [10, 13]
     brightness: 12
 
   - id: 247
     idStr: NETHER_REACTOR_CORE
     name: Nether Reactor Core
     mapcolor: [125, 210, 255]
-    tex: [4, 7]
+    tex: [10, 14]
     data:
-      0: 
-        tex: [4, 7]
+      0:
+        tex: [10, 14]
         name: Nether Reactor Core
-      1: 
-        tex: [6, 7]
+      1:
+        tex: [9, 14]
         name: Nether Reactor Core (Used)
 
   - id: 248
     idStr: UpdateGameBlock
     name: Update Game Block
     mapcolor: [201, 119, 240]
-    tex: [21, 7]
+    tex: [11, 8]
     opacity: 0
 
   - id: 249
     idStr: UpdateGameBlock
-    name: Update Game Block
+    name: UpdateGameBlock
     mapcolor: [201, 119, 240]
-    tex: [21, 7]
+    tex: [11, 8]
     opacity: 0
 
   - id: 253
     idStr: GRASS_CARRIED
     name: Error Grass
     mapcolor: [201, 119, 240]
+    tex: [11, 8]
     opacity: 0
 
   - id: 254
     idStr: LEAVES_CARRIED
     name: Error Leaves
     mapcolor: [201, 119, 240]
+    tex: [11, 8]
     opacity: 0
 
   - id: 255
     idStr: INFO_RESERVED6
     name: Error Stone
     mapcolor: [201, 119, 240]
+    tex: [11, 8]
     opacity: 0
 
 ...

--- a/pocket.yaml
+++ b/pocket.yaml
@@ -18,81 +18,83 @@ blocks:
     idStr: STONE
     name: Stone
     mapcolor: [120, 120, 120]
-    tex: [1, 0]
+    tex: [4, 0]
 
   - id: 2
     idStr: GRASS
     name: Grass
     mapcolor: [117, 176, 73]
-    tex: [0, 0]
+    tex: [3, 0]
     tex_direction:
-      FORWARD: [3, 0]
-      SIDES: [3, 0]
-      BACKWARD: [3, 0]
-      BOTTOM: [2, 0]
+      FORWARD: [1, 0]
+      SIDES: [1, 0]
+      BACKWARD: [1, 0]
+      BOTTOM: [21, 0]
 
   - id: 3
     idStr: DIRT
     name: Dirt
     mapcolor: [134, 96, 67]
-    tex: [2, 0]
+    tex: [21, 0]
 
   - id: 4
     idStr: COBBLESTONE
     name: Cobblestone
     mapcolor: [115, 115, 115]
-    tex: [0, 1]
+    tex: [5, 0]
 
   - id: 5
     idStr: PLANK
     name: Wood Planks
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     data:
       0:
-        name: Wood Planks
-        tex: [4, 0]
+        name: Oak Wood Planks
+        aka: Wood Planks
+        tex: [22, 0]
       1:
-        name: Wood Planks
-        tex: [6, 12]
+        name: Spruce Wood Planks
+        tex: [23, 0]
       2:
-        name: Wood Planks
-        tex: [6, 13]
+        name: Birch Wood Planks
+        tex: [24, 0]
       3:
-        name: Wood Planks
-        tex: [7, 12]
+        name: Jungle Wood Planks
+        tex: [25, 0]
 
   - id: 6
     idStr: SAPLING
     name: Sapling
     mapcolor: [120, 120, 120]
-    tex: [15, 0]
+    tex: [4, 1]
     type: DECORATION_CROSS
     opacity: 0
     data:
-      0:
-        name: Sapling
-        tex: [15, 0]
-      1:
+      0: 
+        name: Oak Sapling
+        aka: Sapling
+        tex: [4, 1]
+      1: 
         name: Spruce Sapling
-        tex: [15, 3]
-      2:
+        tex: [6, 1]
+      2: 
         name: Birch Sapling
-        tex: [15, 4]
+        tex: [5, 1]
 
   - id: 7
     idStr: BEDROCK
     name: Bedrock
     aka: Adminium
     mapcolor: [84, 84, 84]
-    tex: [1, 1]
+    tex: [11, 0]
 
   - id: 8
     idStr: WATER
-    name: Water (active)
+    name: Water (Flowing)
     mapcolor: [38, 92, 255]
     type: WATER
-    tex: [15, 12]
+    tex: [22, 7]
     opacity: 3
 
   - id: 9
@@ -105,9 +107,9 @@ blocks:
 
   - id: 10
     idStr: LAVA
-    name: Lava (active)
+    name: Lava (Flowing)
     mapcolor: [255, 90, 0]
-    tex: [15, 14]
+    tex: [22, 7]
     type: SEMISOLID
     brightness: 15
 
@@ -115,7 +117,7 @@ blocks:
     idStr: STATIONARY_LAVA
     name: Lava
     mapcolor: [255, 90, 0]
-    tex: [15, 14]
+    tex: [23, 7]
     type: SEMISOLID
     brightness: 15
 
@@ -123,13 +125,13 @@ blocks:
     idStr: SAND
     name: Sand
     mapcolor: [218, 210, 158]
-    tex: [2, 1]
+    tex: [14, 0]
 
   - id: 13
     idStr: GRAVEL
     name: Gravel
     mapcolor: [136, 126, 126]
-    tex: [3, 1]
+    tex: [20, 0]
 
   - id: 14
     idStr: GOLD_ORE
@@ -159,18 +161,86 @@ blocks:
       BOTTOM: [5, 1]
     data:
       0:
-        name: Wood
-        tex: [4, 1]
+        name: Oak Wood (Upright)
+        aka: Wood
+        tex: [8, 1]
+        tex_direction:
+          TOP: [9, 1]
+          BOTTOM: [9, 1]
       1:
-        name: Pine Wood
-        aka: Spruce Wood, Redwood
-        tex: [4, 7]
+        name: Spruce Wood (Upright)
+        tex: [12, 1]
+        tex_direction:
+          TOP: [13, 1]
+          BOTTOM: [13, 1]
       2:
-        name: Birch Wood
-        tex: [5, 7]
+        name: Birch Wood (Upright)
+        tex: [10, 1]
+        tex_direction:
+          TOP: [11, 1]
+          BOTTOM: [11, 1]
       3:
-        name: Jungle Wood
-        tex: [9, 9]
+        name: Jungle Wood (Upright)
+        tex: [14, 1]
+        tex_direction:
+          TOP: [15, 1]
+          BOTTOM: [15, 1]
+      4:
+        name: Oak Wood (East/West)
+        tex: [8, 1]
+        tex_direction:
+          SIDES: [9, 1]
+      5:
+        name: Spruce Wood (East/West)
+        tex: [12, 1]
+        tex_direction:
+          SIDES: [13, 1]
+      6:
+        name: Birch Wood (East/West)
+        tex: [10, 1]
+        tex_direction:
+          SIDES: [10, 14]
+      7:
+        name: Jungle Wood (East/West)
+        tex: [14, 1]
+        tex_direction:
+          SIDES: [15, 1]
+      8:
+        name: Oak Wood (North/South)
+        tex: [8, 1]
+        tex_direction:
+          FORWARD: [9, 1]
+          BACKWARD: [9, 1]
+      9:
+        name: Spruce Wood (North/South)
+        tex: [12, 1]
+        tex_direction:
+          FORWARD: [13, 1]
+          BACKWARD: [13, 1]
+      10:
+        name: Birch Wood (North/South)
+        tex: [10, 1]
+        tex_direction:
+          FORWARD: [11, 1]
+          BACKWARD: [11, 1]
+      11:
+        name: Jungle Wood (North/South)
+        tex: [14, 1]
+        tex_direction:
+          FORWARD: [15, 1]
+          BACKWARD: [15, 1]
+      12:
+        name: Oak Wood (Bark Only)
+        tex: [8, 1]
+      13:
+        name: Spruce Wood (Bark Only)
+        tex: [12, 1]
+      14:
+        name: Birch Wood (Bark Only)
+        tex: [10, 1]
+      15:
+        name: Jungle Wood (Bark Only)
+        tex: [14, 1]
 
   - id: 18
     idStr: LEAVES
@@ -181,69 +251,69 @@ blocks:
     opacity: 1
     data:
       0:
-        name: Leaves
+        name: Oak Leaves
         mapcolor: [60, 192, 41]
-        tex: [5, 3]
+        tex: [2, 3]
       1:
-        name: Pine Leaves
-        aka: Spruce Leaves
+        name: Spruce Leaves
+        aka: Pine Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 8]
+        tex: [3, 3]
       2:
         name: Birch Leaves
         mapcolor: [89, 151, 76]
-        tex: [5, 3]
+        tex: [4, 3]
       3:
         name: Jungle Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 12]
+        tex: [5, 3]
 
       4: # bit 0x4 - "Decaying"
-        name: Leaves (Decaying)
+        name: Oak Leaves (Decaying)
         mapcolor: [60, 192, 41]
-        tex: [5, 3]
+        tex: [2, 3]
       5:
-        name: Pine Leaves (Decaying)
+        name: Spruce Leaves (Decaying)
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 8]
+        tex: [3, 3]
       6:
         name: Birch Leaves (Decaying)
         mapcolor: [89, 151, 76]
-        tex: [5, 3]
+        tex: [4, 3]
       7:
         name: Jungle Leaves (Decaying)
         mapcolor: [74, 131, 66]
-        tex: [5, 12]
-      4: # bit 0x8 - "Permanent"
-        name: Leaves (Permanent)
-        mapcolor: [60, 192, 41]
         tex: [5, 3]
+      4: # bit 0x8 - "Permanent"
+        name: Oak Leaves (Permanent)
+        mapcolor: [60, 192, 41]
+        tex: [2, 3]
       5:
-        name: Pine Leaves (Permanent)
+        name: Spruce Leaves (No Decay)
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 8]
+        tex: [3, 3]
       6:
-        name: Birch Leaves (Permanent)
+        name: Birch Leaves (No Decay)
         mapcolor: [89, 151, 76]
-        tex: [5, 3]
+        tex: [4, 3]
       7:
-        name: Jungle Leaves (Permanent)
+        name: Jungle Leaves (No Decay)
         mapcolor: [74, 131, 66]
-        tex: [5, 12]
+        tex: [5, 3]
 
   - id: 19
     idStr: sponge
     name: Sponge
     mapcolor: [193, 193, 57]
-    tex: [0, 3]
+    tex: [24, 2]
 
   - id: 20
     idStr: GLASS
     name: Glass
     mapcolor: [255, 255, 255]
-    tex: [1, 3]
+    tex: [25, 2]
     type: GLASS
     opacity: 0
 
@@ -251,13 +321,13 @@ blocks:
     idStr: LAPIS_LAZULI_ORE
     name: Lapis Lazuli Ore
     mapcolor: [27, 70, 161]
-    tex: [0, 10]
+    tex: [3, 2]
 
   - id: 22
     idStr: LAPIS_LAZULI_BLOCK
     name: Lapis Lazuli Block
     mapcolor: [0, 0, 0]
-    tex: [0, 9]
+    tex: [20 ,1]
 
   - id: 24
     idStr: SANDSTONE
@@ -272,8 +342,11 @@ blocks:
         name: Sandstone
         mapcolor: [218, 210, 158]
         tex: [0, 12]
+        tex_direction:
+          TOP: [0, 11]
+          BOTTOM: [0, 13]
       1:
-        name: Sandstone
+        name: Chiseled Sandstone
         aka: Decorative Sandstone
         mapcolor: [218, 210, 158]
         tex: [5, 14]
@@ -281,8 +354,7 @@ blocks:
           TOP: [0, 11]
           BOTTOM: [0, 11]
       2:
-        name: Sandstone
-        aka: Smooth Sandstone
+        name: Smooth Sandstone
         mapcolor: [218, 210, 158]
         tex: [6, 14]
         tex_direction:
@@ -307,17 +379,17 @@ blocks:
     idStr: goldenRail
     name: Powered Rail
     mapcolor: [120, 53, 28]
-    tex: [3, 11]
+    tex: [0, 5]
     type: SIMPLE_RAIL
     tex_extra:
-      powered: [3, 11]
+      powered: [0, 5]
     opacity: 0
 
   - id: 30
     idStr: WEB
-    name: Web
+    name: Cobweb
     mapcolor: [255, 255, 255]
-    tex: [11, 0]
+    tex: [1, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -328,13 +400,13 @@ blocks:
     tex: [7, 2]
     data:
       0:
-        tex: [7, 3]
+        tex: [11, 2]
         name: (Unused Shrub)
       1:
-        tex: [7, 2]
+        tex: [11, 2]
         name: Tall Grass
       2:
-        tex: [8, 3]
+        tex: [12, 2]
         name: Fern
     type: DECORATION_CROSS
     opacity: 0
@@ -343,7 +415,7 @@ blocks:
     idStr: deadbush
     name: Dead Shrub
     mapcolor: [148, 100, 40]
-    tex: [7, 3]
+    tex: [9, 2]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -351,72 +423,72 @@ blocks:
     idStr: WOOL
     name: White Wool
     mapcolor: [222, 222, 222]
-    tex: [0, 4]
+    tex: [24, 7]
     data:
-      0:
-        tex: [0, 4]
+      0: 
+        tex: [24, 7]
         name: White Wool
         mapcolor: [222, 222, 222]
-      1:
-        tex: [2, 13]
+      1: 
+        tex: [25, 7]
         name: Orange Wool
         mapcolor: [234, 127, 55]
-      2:
-        tex: [2, 12]
+      2: 
+        tex: [26, 7]
         name: Magenta Wool
         mapcolor: [191, 75, 201]
-      3:
-        tex: [2, 11]
+      3: 
+        tex: [27, 7]
         name: Light Blue Wool
         aka: Aqua Wool
         mapcolor: [104, 139, 212]
-      4:
-        tex: [2, 10]
+      4: 
+        tex: [28, 7]
         name: Yellow Wool
         mapcolor: [104, 139, 212]
-      5:
-        tex: [2, 9]
+      5: 
+        tex: [29, 7]
         name: Lime Wool
         mapcolor: [59, 189, 48]
-      6:
-        tex: [2, 8]
+      6: 
+        tex: [30, 7]
         name: Pink Wool
         mapcolor: [217, 131, 155]
-      7:
-        tex: [2, 7]
+      7: 
+        tex: [31, 7]
         name: Gray Wool
         mapcolor: [66, 66, 66]
-      8:
-        tex: [1, 14]
+      8: 
+        tex: [0, 8]
         name: Light Gray Wool
         mapcolor: [166, 166, 166]
-      9:
-        tex: [1, 13]
+      9: 
+        tex: [1, 8]
         name: Cyan Wool
         mapcolor: [39, 117, 149]
-      10:
-        tex: [1, 12]
+      10: 
+        tex: [2, 8]
         name: Purple Wool
         aka: Indigo Wool, Violet Wool
         mapcolor: [129, 54, 196]
-      11:
-        tex: [1, 11]
+      11: 
+        tex: [3, 8]
         name: Blue Wool
         mapcolor: [39, 51, 161]
-      12:
-        tex: [1, 10]
+      12: 
+        tex: [4, 8]
         name: Brown Wool
         mapcolor: [86, 51, 28]
-      13:
-        tex: [1, 9]
+      13: 
+        tex: [5, 8]
         name: Green Wool
         mapcolor: [56, 77, 24]
-      14:
-        tex: [1, 8]
+      14: 
+        tex: [6, 8]
         name: Red Wool
         mapcolor: [164, 45, 41]
-      15:
-        tex: [1, 7]
+      15: 
+        tex: [7, 8]
         name: Black Wool
         mapcolor: [0, 0, 0]
 
@@ -424,14 +496,14 @@ blocks:
     idStr: YELLOW_FLOWER
     name: Flower
     mapcolor: [255, 255, 0]
-    tex: [13, 0]
+    tex: [3, 1]
     type: DECORATION_CROSS
     opacity: 0
 
   - id: 38
-    name: Rose
+    name: Poppy
     mapcolor: [255, 0, 0]
-    tex: [12, 0]
+    tex: [2, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -439,7 +511,7 @@ blocks:
     idStr: BROWN_MUSHROOM
     name: Brown Mushroom
     mapcolor: [145, 109, 85]
-    tex: [13, 1]
+    tex: [31, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -447,7 +519,7 @@ blocks:
     idStr: RED_MUSHROOM
     name: Red Mushroom
     mapcolor: [226, 18, 18]
-    tex: [12, 1]
+    tex: [30, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -455,134 +527,162 @@ blocks:
     idStr: GOLD_BLOCK
     name: Block of Gold
     mapcolor: [231, 165, 45]
-    tex: [7, 1]
+    tex: [17, 1]
 
   - id: 42
     idStr: IRON_BLOCK
     name: Block of Iron
     mapcolor: [191, 191, 191]
-    tex: [6, 1]
+    tex: [16, 1]
 
   - id: 43
     idStr: DOUBLE_SLAB
-    name: Double Stone Slab
+    name: Stone Slab (Double)
     aka: Step
     mapcolor: [200, 200, 200]
-    tex: [5, 0]
-    tex_direction:
-      TOP: [6, 0]
-      BOTTOM: [6, 0]
-      FORWARD: [5, 0]
-      BACKWARD: [5, 0]
-      SIDES: [5, 0]
-
+    tex: [27, 0]
     data:
       0:
-        tex: [5, 0]
         name: Double Stone Slab
+        tex: [27, 0]
+        tex_direction:
+          TOP: [26, 0]
+          BOTTOM: [26, 0]
       1:
-        tex: [0, 12]
         name: Double Sandstone Slab
-      2:
-        tex: [4, 0]
-        name: Double Wooden Slab
-      3:
-        tex: [0, 1]
+        tex: [15, 0]
+        tex_direction:
+          TOP: [0, 18]
+          BOTTOM: [0, 19]
+      2: 
+        name: Double Wooden Slab (Old)
+        tex: [22, 0]
+      3: 
         name: Double Cobblestone Slab
-      4:
-        tex: [7, 0]
+        tex: [5, 0]
+      4: 
         name: Double Brick Slab
+        tex: [28, 0]
       5:
-        tex: [6, 3]
         name: Double Stone Brick Slab
+        tex: [7, 0]
       6:
-        tex: [9, 13]
         name: Double Quartz Slab
+        tex: [25, 1]
       7:
-        tex: [9, 13]
-        name: Double Solid Stone Slab
+        name: Smooth Double Stone Slab
+        tex: [26, 0]
 
   - id: 44
-    idStr: SLAB
-    name: Stone Slab
+    name: Slab
     aka: Half Step
     mapcolor: [200, 200, 200]
-    tex: [6, 0]
-    tex_direction:
-      TOP: [6, 0]
-      BOTTOM: [6, 0]
-      FORWARD: [5, 0]
-      BACKWARD: [5, 0]
-      SIDES: [5, 0]
+    tex: [27, 0]
+    type: HALFHEIGHT
     data:
       0:
-        tex: [6, 0]
         name: Stone Slab
+        tex: [27, 0]
+        tex_direction:
+          TOP: [26, 0]
+          BOTTOM: [26, 0]
       1:
-        tex: [0, 12]
         name: Sandstone Slab
-      2:
-        tex: [4, 0]
+        tex: [15, 0]
+        tex_direction:
+          TOP: [0, 18]
+          BOTTOM: [0, 19]
+      2: 
         name: Wooden Slab
-      3:
-        tex: [0, 1]
+        tex: [22, 0]
+      3: 
         name: Cobblestone Slab
-      4:
-        tex: [7, 0]
+        tex: [5, 0]
+      4: 
         name: Brick Slab
+        tex: [28, 0]
       5:
-        tex: [6, 3]
         name: Stone Brick Slab
+        tex: [7, 0]
       6:
-        tex: [9, 13]
         name: Quartz Slab
+        tex: [25, 1]
       7:
-        tex: [9, 13]
-        name: Solid Stone Slab
-    type: HALFHEIGHT
+        name: Smooth Stone Slab
+        tex: [26, 0]
+      8:
+        name: Stone Slab (Upper)
+        tex: [27, 0]
+        tex_direction:
+          TOP: [26, 0]
+          BOTTOM: [26, 0]
+      9:
+        name: Sandstone Slab (Upper)
+        tex: [15, 0]
+        tex_direction:
+          TOP: [0, 18]
+          BOTTOM: [0, 19]
+      10:
+        name: Wooden Slab (Old) (Upper}
+        tex: [22, 0]
+      11:
+        name: Cobblestone Slab (Upper)
+        tex: [5, 0]
+      12:
+        name: Brick Slab (Upper)
+        tex: [28, 0]
+      13:
+        name: Stone Brick Slab (Upper)
+        tex: [7, 0]
+      14:
+        name: Quartz Slab (Upper)
+        tex: [25, 1]
+      15:
+        name: Smooth Stone Slab (Upper)
+        tex: [26, 0]
 
   - id: 45
     idStr: BRICK
     name: Brick
     mapcolor: [170, 86, 62]
-    tex: [7, 0]
+    tex: [28, 0]
 
   - id: 46
     idStr: TNT
     name: TNT
     mapcolor: [160, 83, 65]
-    tex: [8, 0]
+    tex: [29, 0]
     tex_direction:
-      TOP: [9, 0]
-      BOTTOM: [10, 0]
+      TOP: [30, 0]
+      BOTTOM: [31, 0]
 
   - id: 47
     idStr: BOOKSHELF
     name: Bookshelf
     mapcolor: [188, 152, 98]
-    tex: [3, 2]
+    tex: [0, 1]
     tex_direction:
-      TOP: [4, 0]
-      BOTTOM: [4, 0]
+      TOP: [22, 0]
+      BOTTOM: [22, 0]
 
   - id: 48
     idStr: MOSSY_COBBLESTONE
     name: Moss Stone
     aka: Mossy Cobblestone
     mapcolor: [115, 169, 115]
-    tex: [4, 2]
+    tex: [6, 0]
 
   - id: 49
     idStr: OBSIDIAN
     name: Obsidian
     mapcolor: [26, 11, 43]
-    tex: [5, 2]
+    tex: [12, 0]
 
   - id: 50
     idStr: TORCH
     name: Torch
     mapcolor: [245, 220, 50]
-    tex: [0, 5]
+    tex: [18, 3]
     type: TORCH
     explored: true
     opacity: 0
@@ -593,133 +693,205 @@ blocks:
     name: Fire
     mapcolor: [255, 170, 30]
     type: SEMISOLID
-    tex: [15, 1]
+    tex: [8, 8]
     opacity: 0
     brightness: 15
 
   - id: 53
-    idStr: WOODEN_STAIRS
-    name: Wooden Stairs
+    idStr: oak_stairs
+    name: Oak Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     type: STAIRS
 
   - id: 54
-    idStr: CHEST
+    idStr: chest
     name: Chest
     mapcolor: [125, 91, 38]
-    tex: [11, 1]
+    tex: [19, 7]
     type: CHEST
-    tex_extra:
-      side_small: [10, 1]
-      top: [9, 1]
-      front_big_left: [9, 2]
-      front_big_right: [10, 2]
-      back_big_left: [9, 3]
-      back_big_right: [10, 3]
+#   For whatever reason the external file wasn't being loaded, put in something a bit simpler until it is fixed.
+#   tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
+#   Currently not working properly, using standard damage entries for now, null entries face north ingame.
+    data:
+#     0:
+#       null
+#     1:
+#       null
+      2: 
+        name: Chest (North)
+        tex_direction:
+          FORWARD: [20, 7]
+          TOP: [18, 7]
+          BOTTOM: [18, 7]
+      3: 
+        name: Chest (South)
+        tex_direction:
+          BACKWARD: [20, 7]
+          TOP: [18, 7]
+          BOTTOM: [18, 7]
+      4: 
+        name: Chest (West)
+        tex_direction:
+          LEFT: [20, 7]
+          TOP: [18, 7]
+          BOTTOM: [18, 7]
+      5: 
+        name: Chest (East)
+        tex_direction:
+          RIGHT: [20, 7]
+          TOP: [18, 7]
+          BOTTOM: [18, 7]
     opacity: 0
 
   - id: 56
     idStr: DIAMOND_ORE
     name: Diamond Ore
     mapcolor: [129, 140, 143]
-    tex: [2, 3]
+    tex: [4, 2]
 
   - id: 57
     idStr: DIAMOND_BLOCK
     name: Block of Diamond
     mapcolor: [45, 166, 152]
-    tex: [8, 1]
+    tex: [18, 1]
 
   - id: 58
     idStr: WORKBENCH
     name: Crafting Table
+    aka: Workbench
     mapcolor: [114, 88, 56]
-    tex: [12, 3]
+    tex: [15, 2]
     tex_direction:
-      SIDES: [11, 3]
-      TOP: [11, 2]
-      BOTTOM: [4, 0]
+      SIDES: [14, 2]
+      TOP: [13, 2]
+      BOTTOM: [22, 0]
 
   - id: 59
     idStr: CROPS
     name: Crops
     aka: Wheat
     mapcolor: [146, 192, 0]
-    tex: [15, 5]
+    tex: [5, 4]
     type: CROPS
     data:
-      0: {tex: [8, 5]}
-      1: {tex: [9, 5]}
-      2: {tex: [10, 5]}
-      3: {tex: [11, 5]}
-      4: {tex: [12, 5]}
-      5: {tex: [13, 5]}
-      6: {tex: [14, 5]}
-      7: {tex: [15, 5]}
+      0: {tex: [30, 3]}
+      1: {tex: [31, 3]}
+      2: {tex: [0, 4]}
+      3: {tex: [1, 4]}
+      4: {tex: [2, 4]}
+      5: {tex: [3, 4]}
+      6: {tex: [4, 4]}
+      7: {tex: [5, 4]}
     opacity: 0
 
   - id: 60
     idStr: FARMLAND
     name: Farmland
     mapcolor: [95, 58, 30]
-    tex: [6, 5]
+    tex: [29, 3]
     tex_direction:
-      FORWARD: [2, 0]
-      SIDES: [2, 0]
-      BACKWARD: [2, 0]
-      BOTTOM: [2, 0]
+      FORWARD: [21, 0]
+      SIDES: [21, 0]
+      BACKWARD: [21, 0]
+      BOTTOM: [21, 0]
 
   - id: 61
-    idStr: FURNACE
+    idStr: furnace
     name: Furnace
     mapcolor: [96, 96, 96]
-    tex: [12, 2]
-    tex_direction:
-      FORWARD: [12, 2]
-      SIDES: [13, 2]
-      BACKWARD: [13, 2]
-      TOP: [14, 3]
-      BOTTOM: [14, 3]
-    tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
+    tex: [18, 2]
+#    tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
+    data:
+#     0:
+#       null
+#     1:
+#       null
+      2: 
+        name: Furnace (North)
+        tex_direction:
+          FORWARD: [16, 2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
+      3: 
+        name: Furnace (South)
+        tex_direction:
+          BACKWARD: [16, 2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
+      4: 
+        name: Furnace (West)
+        tex_direction:
+          LEFT: [16, 2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
+      5: 
+        name: Furnace (East)
+        tex_direction:
+          RIGHT: [16, 2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
 
   - id: 62
-    idStr: BURNING_FURNACE
-    name: Burning Furnace
+    idStr: lit_furnace
+    name: Lit Furnace
     mapcolor: [96, 96, 96]
-    tex: [13, 3]
-    tex_direction:
-      FORWARD: [13, 3]
-      SIDES: [13, 2]
-      BACKWARD: [13, 2]
-      TOP: [14, 3]
-      BOTTOM: [14, 3]
-    tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
-    brightness: 14
+    tex: [18, 2]
+#    tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
+    data:
+#     0:
+#       null
+#     1:
+#       null
+      2: 
+        name: Lit Furnace (North)
+        tex_direction:
+          FORWARD: [17 ,2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
+      3: 
+        name: Lit Furnace (South)
+        tex_direction:
+          BACKWARD: [17 ,2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
+      4: 
+        name: Lit Furnace (West)
+        tex_direction:
+          LEFT: [17 ,2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
+      5: 
+        name: Lit Furnace (East)
+        tex_direction:
+          RIGHT: [17 ,2]
+          TOP: [19, 2]
+          BOTTOM: [19, 2]
+    brightness: 13
 
   - id: 63
-    idStr: sign
-    name: Sign
+    idStr: standing_sign
+    name: Sign Post
     mapcolor: [111, 91, 54]
-    tex: [4, 0]
+    tex: [22, 0]
     type: SIGNPOST
     opacity: 0
 
   - id: 64
-    idStr: WOODEN_DOOR
+    idStr: wooden_door
     name: Wooden Door
     mapcolor: [136, 109, 67]
-    tex: [1, 5]
+    tex: [22, 3]
     type: DOOR
     tex_extra:
-      bottom: [1, 6]
+      bottom: [21, 3]
     opacity: 0
 
   - id: 65
     idStr: LADDER
     name: Ladder
     mapcolor: [181, 140, 64]
-    tex: [3, 5]
+    tex: [25, 3]
     type: LADDER
     opacity: 0
 
@@ -727,55 +899,55 @@ blocks:
     idStr: rail
     name: Rail
     mapcolor: [150, 134, 102]
-    tex: [0, 8]
+    tex: [29, 4]
     type: MINECART_TRACKS
     tex_extra:
-      curve: [0, 7]
+      curve: [20, 4]
     opacity: 0
 
   - id: 67
-    idStr: COBBLESTONE_STAIRS
-    name: Stone Stairs
+    idStr: stone_stairs
+    name: Cobblestone Stairs
     mapcolor: [115, 115, 115]
-    tex: [0, 1]
+    tex: [5, 0]
     type: STAIRS
 
   - id: 68
-    idStr: sign
+    idStr: wall_sign
     name: Wall Sign
     mapcolor: [111, 91, 54]
-    tex: [4, 0]
+    tex: [22, 0]
     type: WALLSIGN
     opacity: 0
 
   - id: 71
-    idStr: IRON_DOOR
+    idStr: iron_door
     name: Iron Door
     mapcolor: [191, 191, 191]
-    tex: [2, 5]
+    tex: [24, 3]
     type: DOOR
     tex_extra:
-      bottom: [2, 6]
+      bottom: [23, 3]
     opacity: 0
 
   - id: 73
     idStr: REDSTONE_ORE
     name: Redstone Ore
     mapcolor: [131, 107, 107]
-    tex: [3, 3]
+    tex: [5, 2]
 
   - id: 74
     idStr: GLOWING_REDSTONE_ORE
     name: Redstone Ore (Glowing)
     mapcolor: [131, 107, 107]
-    tex: [3, 3]
+    tex: [5, 2]
     brightness: 9
 
   - id: 78
     idStr: SNOW
     name: Snow Layer
     mapcolor: [255, 255, 255]
-    tex: [2, 4]
+    tex: [7, 3]
     type: THINSLICE
     opacity: 0
 
@@ -783,7 +955,7 @@ blocks:
     idStr: ICE
     name: Ice
     mapcolor: [83, 113, 163]
-    tex: [3, 4]
+    tex: [8, 3]
     type: WATER
     opacity: 3
 
@@ -791,37 +963,38 @@ blocks:
     idStr: SNOW_BLOCK
     name: Snow
     mapcolor: [250, 250, 250]
-    tex: [2, 4]
+    tex: [7, 3]
 
   - id: 81
     idStr: CACTUS
     name: Cactus
     mapcolor: [25, 120, 25]
-    tex: [6, 4]
+    tex: [10, 3]
     tex_direction:
-      TOP: [5, 4]
-      BOTTOM: [5, 4]
+      TOP: [9, 3]
+      BOTTOM: [11, 3]
     opacity: 0
 
   - id: 82
     idStr: CLAY
     name: Clay
     mapcolor: [151, 157, 169]
-    tex: [8, 4]
+    tex: [13, 0]
 
   - id: 83
-    idStr: SUGARCANE
+    idStr: reeds
     name: Sugar Cane
+    aka: Reeds, Papyrus
     mapcolor: [100, 67, 50]
-    tex: [9, 4]
+    tex: [12, 3]
     type: DECORATION_CROSS
     opacity: 0
 
   - id: 85
-    idStr: FENCE
+    idStr: fence
     name: Fence
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     type: FENCE
     opacity: 0
 
@@ -829,54 +1002,92 @@ blocks:
     idStr: pumpkin
     name: Pumpkin
     mapcolor: [227, 144, 29]
-    tex: [7, 7]
-    tex_direction:
-      FORWARD: [7, 7]
-      SIDES: [6, 7]
-      BACKWARD: [6, 7]
-      TOP: [6, 6]
-      BOTTOM: [6, 6]
-    tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
+    tex: [8, 4]
+#   tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
+    data:
+      0: 
+        name: Pumpkin (South)
+        tex_direction:
+          BACKWARD: [9, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
+      1: 
+        name: Pumpkin (West)
+        tex_direction:
+          LEFT: [9, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
+      2: 
+        name: Pumpkin (North)
+        tex_direction:
+          FORWARD: [9, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
+      3: 
+        name: Pumpkin (East)
+        tex_direction:
+          RIGHT: [9, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
 
   - id: 87
-    idStr: hellrock
+    idStr: netherrack
     name: Netherrack
     mapcolor: [104, 8, 8]
-    tex: [7, 6]
+    tex: [11, 4]
 
   - id: 89
     idStr: GLOWSTONE
     name: Glowstone
     mapcolor: [249, 212, 156]
-    tex: [9, 6]
+    tex: [17, 4]
     explored: true
     brightness: 15
 
   - id: 91
-    idStr: litpumpkin
+    idStr: lit_pumpkin
     name: Jack-o'-Lantern
     mapcolor: [249, 255, 58]
     explored: true
-    tex: [8, 7]
-    tex_direction:
-      FORWARD: [8, 7]
-      SIDES: [6, 7]
-      BACKWARD: [6, 7]
-      TOP: [6, 6]
-      BOTTOM: [6, 6]
-    tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
+    tex: [8, 4]
+#   tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
+    data:
+      0: 
+        name: Jack-o'-Lantern (South)
+        tex_direction:
+          BACKWARD: [10, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
+      1: 
+        name: Jack-o'-Lantern (West)
+        tex_direction:
+          LEFT: [10, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
+      2: 
+        name: Jack-o'-Lantern (North)
+        tex_direction:
+          FORWARD: [10, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
+      3: 
+        name: Jack-o'-Lantern (East)
+        tex_direction:
+          RIGHT: [10, 4]
+          TOP: [7, 4]
+          BOTTOM: [7, 4]
     brightness: 15
 
   - id: 92
     idStr: cake
     name: Cake
     mapcolor: [234, 233, 235]
-    tex: [9, 7]
+    tex: [19, 5]
     type: CAKE
     tex_extra:
-      side_uncut: [10, 7]
-      side_cut: [11, 7]
-      bottom: [12, 7]
+      side_uncut: [20 ,5]
+      side_cut: [18, 5]
+      bottom: [17, 5]
     opacity: 0
 
   - id: 95
@@ -884,37 +1095,37 @@ blocks:
     name: Invisible Bedrock
 
   - id: 96
-    idStr: TRAPDOOR
+    idStr: trapdoor
     name: Trapdoor
     mapcolor: [143, 107, 53]
-    tex: [4, 5]
+    tex: [26, 3]
     type: TRAPDOOR
     opacity: 0
 
   - id: 98
-    idStr: STONE_BRICK
+    idStr: stonebrick
     name: Stone Bricks
     mapcolor: [120, 120, 120]
-    tex: [6, 3]
+    tex: [7, 0]
     data:
       0:
-        tex: [6, 3]
         name: Stone Bricks
+        tex: [7, 0]
       1:
-        tex: [4, 6]
         name: Mossy Stone Bricks
+        tex: [8, 0]
       2:
-        tex: [5, 6]
         name: Cracked Stone Bricks
+        tex: [9, 0]
       3:
-        tex: [5, 13]
-        name: Circle Stone Bricks
+        name: Chiseled Stone Bricks
+        tex: [10, 0]
 
   - id: 101
     idStr: fenceIron
     name: Iron Bars
     mapcolor: [77, 77, 78]
-    tex: [5, 5]
+    tex: [27, 3]
     type: SOLID_PANE
     opacity: 0
 
@@ -922,7 +1133,7 @@ blocks:
     idStr: GLASS_PANE
     name: Glass Pane
     mapcolor: [255, 255, 255]
-    tex: [1, 3]
+    tex: [25, 2]
     type: SOLID_PANE
     opacity: 0
 
@@ -930,37 +1141,36 @@ blocks:
     idStr: MELON
     name: Watermelon
     mapcolor: [190, 184, 41]
-    tex: [9, 8]
+    tex: [23, 4]
     tex_direction:
-      FORWARD: [8, 8]
-      SIDES: [8, 8]
-      BACKWARD: [8, 8]
+      TOP: [24, 4]
+      BOTTOM: [24, 4]
 
   - id: 104
     idStr: pumpkinStem
     name: Pumpkin Stem
     mapcolor: [227, 144, 29]
-    tex: [15, 6]
+    tex: [27, 4]
     type: STEM
     tex_extra:
-      curve: [15, 7]
+      curve: [28, 4]
     opacity: 0
 
   - id: 105
     idStr: MELON_STEM
     name: Melon Stem
     mapcolor: [190, 184, 41]
-    tex: [15, 6]
+    tex: [25, 4]
     type: STEM
     tex_extra:
-      curve: [15, 7]
+      curve: [26, 4]
     opacity: 0
 
   - id: 107
     idStr: FENCE_GATE
     name: Fence Gate
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     type: FENCE_GATE
     opacity: 0
 
@@ -968,233 +1178,313 @@ blocks:
     idStr: BRICK_STAIRS
     name: Brick Stairs
     mapcolor: [170, 86, 62]
-    tex: [7, 0]
+    tex: [28, 0]
     type: STAIRS
-
+    
   - id: 109
     idStr: stairsStoneBrickSmooth
     name: Stone Brick Stairs
     mapcolor: [120, 120, 120]
-    tex: [6, 3]
+    tex: [7, 0]
     type: STAIRS
 
   - id: 112
     idStr: netherBrick
     name: Nether Brick
     mapcolor: [54, 24, 30]
-    tex: [0, 14]
-
+    tex: [12, 4]
+    
   - id: 114
     idStr: stairsNetherBrick
-    name: Nether Stairs
+    name: Nether Brick Stairs
     mapcolor: [54, 24, 30]
-    tex: [0, 14]
+    tex: [12, 4]
     type: STAIRS
 
   - id: 128
     idStr: stairsSandStone
     name: Sandstone Stairs
     mapcolor: [157, 128, 79]
-    tex: [0, 12]
+    tex: [15, 0]
     type: STAIRS
 
   - id: 134
-    idStr: stairsWoodSpruce
-    name: Spruce-Wood Stairs
+    idStr: spruce_stairs
+    name: Spruce Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [6, 12]
+    tex: [23, 0]
     type: STAIRS
 
   - id: 135
-    idStr: stairsWoodBirch
-    name: Birch-Wood Stairs
+    idStr: birch_stairs
+    name: Birch Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [6, 13]
+    tex: [24, 0]
     type: STAIRS
 
   - id: 136
-    idStr: stairsWoodJungle
-    name: Jungle-Wood Stairs
+    idStr: jungle_stairs
+    name: Jungle Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [7, 12]
+    tex: [25, 0]
     type: STAIRS
 
   - id: 139
-    idStr: cobbleWall
+    idStr: cobblestone_wall
     name: Cobblestone Wall
     mapcolor: [128, 128, 128]
-    tex: [0, 1]
+    tex: [5, 0]
     type: FENCE
     data:
       0:
-        tex: [0, 1]
         name: Cobblestone Wall
+        tex: [5, 0]
       1:
-        tex: [4, 2]
         name: Mossy Cobblestone Wall
+        tex: [6, 0]
     opacity: 0
 
   - id: 141
     idStr: carrots
     name: Carrots
     mapcolor: [200, 100, 100]
-    tex: [11, 11]
+    tex: [24, 6]
     type: CROPS
     data:
-      0: {tex: [8, 11]}
-      1: {tex: [9, 11]}
-      2: {tex: [10, 11]}
-      3: {tex: [11, 11]}
+      0: {tex: [21, 6]}
+      1: {tex: [22, 6]}
+      2: {tex: [23, 6]}
+      3: {tex: [24, 6]}
     opacity: 0
 
   - id: 142
     idStr: potatoes
     name: Potatoes
     mapcolor: [200, 100, 100]
-    tex: [12, 11]
+    tex: [28, 6]
     type: CROPS
     data:
-      0: {tex: [8, 11]}
-      1: {tex: [9, 11]}
-      2: {tex: [10, 11]}
-      3: {tex: [12, 11]}
+      0: {tex: [25, 6]}
+      1: {tex: [26, 6]}
+      2: {tex: [27, 6]}
+      3: {tex: [28, 6]}
     opacity: 0
 
   - id: 155
-    idStr: quartzBlock
+    idStr: quartz_block
     name: Block of Quartz
     mapcolor: [255, 255, 255]
-    tex: [9, 13]
+    tex: [25, 1]
+    data:
+      0:
+        name: Block of Quartz
+        tex: [25, 1]
+        tex_direction:
+          TOP: [1, 24]
+          BOTTOM: [1, 23]
+      1:
+        name: Chiseled Quartz Block
+        tex: [1, 28]
+        tex_direction:
+          TOP: [1, 29]
+          BOTTOM: [1, 29]
+      2:
+        name: Pillar Quartz Block
+        tex: [1, 26]
+        tex_direction:
+          TOP: [1, 27]
+          BOTTOM: [1, 27]
 
   - id: 156
-    idStr: stairsQuartz
+    idStr: quartz_stairs
     name: Quartz Stairs
     mapcolor: [255, 255, 255]
-    tex: [9, 13]
+    tex: [25, 1]
     type: STAIRS
 
   - id: 157
-    idStr: woodSlab
+    idStr: double_wooden_slab
     name: Wooden Double Slab
-    aka: Wood Double Step
     mapcolor: [200, 200, 200]
-    tex: [4, 0]
+    tex: [22, 0]
     data:
       0:
-        tex: [4, 0]
-        name: Oak-Wood Double Slab
+        name: Double Oak Wood Slab
       1:
-        tex: [6, 12]
-        name: Spruce-Wood Double Slab
+        name: Double Spruce Wood Slab
+        tex: [23, 0]
       2:
-        tex: [6, 13]
-        name: Birch-Wood Double Slab
+        name: Double Birch Wood Slab
+        tex: [24, 0]
       3:
-        tex: [7, 12]
-        name: Jungle-Wood Double Slab
+        name: Double Jungle Wood Slab
+        tex: [25, 0]
 
   - id: 158
     idStr: woodSlab
     name: Wooden Slab
     aka: Wood Half Step
     mapcolor: [200, 200, 200]
-    tex: [4, 0]
+    tex: [22, 0]
+    type: HALFHEIGHT
     data:
       0:
-        tex: [4, 0]
-        name: Oak-Wood Slab
+        name: Oak Wood Slab
       1:
-        tex: [6, 12]
-        name: Spruce-Wood Slab
+        name: Spruce Wood Slab
+        tex: [23, 0]
       2:
-        tex: [6, 13]
-        name: Birch-Wood Slab
+        name: Birch Wood Slab
+        tex: [24, 0]
       3:
-        tex: [7, 12]
-        name: Jungle-Wood Slab
-    type: HALFHEIGHT
+        name: Jungle Wood Slab
+        tex: [25, 0]
 
   - id: 170
+    idStr: hay_block
     name: Hay Block
-    mapcolor: [206, 170, 28]
+    tex: [11, 6]
     tex_direction:
-      TOP: [7, 13]
-      FORWARD: [8, 13]
-      SIDES: [8, 13]
-      BACKWARD: [8, 13]
-      BOTTOM: [7, 13]
+      FORWARD: [12, 6]
+      SIDES: [12, 6]
+      BACKWARD: [12, 6]
 
   - id: 171
     name: Carpet
+    tex: [24, 7]
+    type: THINSLICE
     opacity: 0
+    data:
+      0: 
+        name: White Carpet
+        tex: [24, 7]
+        mapcolor: [222, 222, 222]
+      1: 
+        name: Orange Carpet
+        tex: [25, 7]
+        mapcolor: [234, 127, 55]
+      2: 
+        name: Magenta Carpet
+        tex: [26, 7]
+        mapcolor: [191, 75, 201]
+      3: 
+        name: Light Blue Carpet
+        tex: [27, 7]
+        mapcolor: [104, 139, 212]
+      4: 
+        name: Yellow Carpet
+        tex: [28, 7]
+        mapcolor: [104, 139, 212]
+      5: 
+        name: Lime Carpet
+        tex: [29, 7]
+        mapcolor: [59, 189, 48]
+      6: 
+        name: Pink Carpet
+        tex: [30, 7]
+        mapcolor: [217, 131, 155]
+      7: 
+        name: Gray Carpet
+        tex: [31, 7]
+        mapcolor: [66, 66, 66]
+      8: 
+        name: Light Gray Carpet
+        tex: [0, 8]
+        mapcolor: [166, 166, 166]
+      9: 
+        name: Cyan Carpet
+        tex: [1, 8]
+        mapcolor: [39, 117, 149]
+      10: 
+        name: Purple Carpet
+        tex: [2, 8]
+        mapcolor: [129, 54, 196]
+      11: 
+        name: Blue Carpet
+        tex: [3, 8]
+        mapcolor: [39, 51, 161]
+      12: 
+        name: Brown Carpet
+        tex: [4, 8]
+        mapcolor: [86, 51, 28]
+      13: 
+        name: Green Carpet
+        tex: [5, 8]
+        mapcolor: [56, 77, 24]
+      14: 
+        name: Red Carpet
+        tex: [6, 8]
+        mapcolor: [164, 45, 41]
+      15: 
+        name: Black Carpet
+        tex: [7, 8]
+        mapcolor: [0, 0, 0]
 
   - id: 173
     idStr: blockcoal
     name: Block of Coal
     mapcolor: [100, 100, 100]
-    tex: [12, 13]
-    opacity: 0
+    tex: [19, 1]
 
   - id: 245
     idStr: STONECUTTER
     name: Stonecutter
     mapcolor: [96, 96, 96]
-    tex: [11, 8]
-    opacity: 0
+    tex: [22, 2]
+    tex_direction:
+      FORWARD: [20, 2]
+      SIDES: [21, 2]
+      BACKWARD: [20, 2]
+      BOTTOM: [23, 2]
 
   - id: 246
     idStr: GLOWING_OBSIDIAN
     name: Glowing Obsidian
     mapcolor: [155, 0, 0]
-    tex: [10, 13]
+    tex: [7, 7]
     brightness: 12
 
   - id: 247
     idStr: NETHER_REACTOR_CORE
     name: Nether Reactor Core
     mapcolor: [125, 210, 255]
-    tex: [10, 14]
+    tex: [4, 7]
     data:
       0:
-        tex: [10, 14]
+        tex: [4, 7]
         name: Nether Reactor Core
       1:
-        tex: [9, 14]
+        tex: [6, 7]
         name: Nether Reactor Core (Used)
 
   - id: 248
     idStr: UpdateGameBlock
     name: Update Game Block
     mapcolor: [201, 119, 240]
-    tex: [11, 8]
-    opacity: 0
+    tex: [21, 7]
 
   - id: 249
     idStr: UpdateGameBlock
-    name: UpdateGameBlock
+    name: Update Game Block
     mapcolor: [201, 119, 240]
-    tex: [11, 8]
-    opacity: 0
+    tex: [21, 7]
 
   - id: 253
     idStr: GRASS_CARRIED
     name: Error Grass
     mapcolor: [201, 119, 240]
     tex: [11, 8]
-    opacity: 0
 
   - id: 254
     idStr: LEAVES_CARRIED
     name: Error Leaves
     mapcolor: [201, 119, 240]
     tex: [11, 8]
-    opacity: 0
 
   - id: 255
     idStr: INFO_RESERVED6
     name: Error Stone
     mapcolor: [201, 119, 240]
     tex: [11, 8]
-    opacity: 0
 
 ...

--- a/pocket.yaml
+++ b/pocket.yaml
@@ -18,81 +18,85 @@ blocks:
     idStr: STONE
     name: Stone
     mapcolor: [120, 120, 120]
-    tex: [1, 0]
+    tex: [4, 0]
 
   - id: 2
     idStr: GRASS
     name: Grass
     mapcolor: [117, 176, 73]
-    tex: [0, 0]
+    tex: [3, 0]
     tex_direction:
-      FORWARD: [3, 0]
-      SIDES: [3, 0]
-      BACKWARD: [3, 0]
-      BOTTOM: [2, 0]
+      FORWARD: [1, 0]
+      SIDES: [1, 0]
+      BACKWARD: [1, 0]
+      BOTTOM: [21, 0]
 
   - id: 3
     idStr: DIRT
     name: Dirt
     mapcolor: [134, 96, 67]
-    tex: [2, 0]
+    tex: [21, 0]
 
   - id: 4
     idStr: COBBLESTONE
     name: Cobblestone
     mapcolor: [115, 115, 115]
-    tex: [0, 1]
+    tex: [5, 0]
 
   - id: 5
     idStr: PLANK
     name: Wood Planks
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     data:
       0:
         name: Wood Planks
-        tex: [4, 0]
+        aka: Oak Wood Planks
+        tex: [22, 0]
       1:
         name: Wood Planks
-        tex: [6, 12]
+        aka: Spruce Wood Planks
+        tex: [23, 0]
       2:
         name: Wood Planks
-        tex: [6, 13]
+        aka: Birch Wood Planks
+        tex: [24, 0]
       3:
         name: Wood Planks
-        tex: [7, 12]
+        aka: Jungle Wood Planks
+        tex: [25, 0]
 
   - id: 6
     idStr: SAPLING
     name: Sapling
     mapcolor: [120, 120, 120]
-    tex: [15, 0]
+    tex: [4, 1]
     type: DECORATION_CROSS
     opacity: 0
     data:
-      0:
+      0: 
         name: Sapling
-        tex: [15, 0]
-      1:
+        tex: [4, 1]
+      1: 
         name: Spruce Sapling
-        tex: [15, 3]
-      2:
+        tex: [6, 1]
+      2: 
         name: Birch Sapling
-        tex: [15, 4]
+        tex: [5, 1]
 
   - id: 7
     idStr: BEDROCK
     name: Bedrock
     aka: Adminium
     mapcolor: [84, 84, 84]
-    tex: [1, 1]
+    tex: [11, 0]
 
   - id: 8
     idStr: WATER
     name: Water (active)
     mapcolor: [38, 92, 255]
     type: WATER
-    tex: [15, 12]
+    tex: [22, 7]
     opacity: 3
 
   - id: 9
@@ -100,14 +104,14 @@ blocks:
     name: Water
     mapcolor: [38, 92, 255]
     type: WATER
-    tex: [15, 12]
+    tex: [22, 7]
     opacity: 3
 
   - id: 10
     idStr: LAVA
     name: Lava (active)
     mapcolor: [255, 90, 0]
-    tex: [15, 14]
+    tex: [23, 7]
     type: SEMISOLID
     brightness: 15
 
@@ -115,7 +119,7 @@ blocks:
     idStr: STATIONARY_LAVA
     name: Lava
     mapcolor: [255, 90, 0]
-    tex: [15, 14]
+    tex: [23, 7]
     type: SEMISOLID
     brightness: 15
 
@@ -123,13 +127,13 @@ blocks:
     idStr: SAND
     name: Sand
     mapcolor: [218, 210, 158]
-    tex: [2, 1]
+    tex: [14, 0]
 
   - id: 13
     idStr: GRAVEL
     name: Gravel
     mapcolor: [136, 126, 126]
-    tex: [3, 1]
+    tex: [20, 0]
 
   - id: 14
     idStr: GOLD_ORE
@@ -153,24 +157,24 @@ blocks:
     idStr: WOOD
     name: Wood
     mapcolor: [102, 81, 51]
-    tex: [4, 1]
+    tex: [8, 1]
     tex_direction:
-      TOP: [5, 1]
-      BOTTOM: [5, 1]
+      TOP: [9, 1]
+      BOTTOM: [9, 1]
     data:
       0:
         name: Wood
-        tex: [4, 1]
+        tex: [8, 1]
       1:
         name: Pine Wood
         aka: Spruce Wood, Redwood
-        tex: [4, 7]
+        tex: [12, 1]
       2:
         name: Birch Wood
-        tex: [5, 7]
+        tex: [10, 1]
       3:
         name: Jungle Wood
-        tex: [9, 9]
+        tex: [14, 1]
 
   - id: 18
     idStr: LEAVES
@@ -183,67 +187,68 @@ blocks:
       0:
         name: Leaves
         mapcolor: [60, 192, 41]
-        tex: [5, 3]
+        tex: [2, 3]
       1:
         name: Pine Leaves
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 8]
+        tex: [3, 3]
       2:
         name: Birch Leaves
         mapcolor: [89, 151, 76]
-        tex: [5, 3]
+        tex: [4, 3]
       3:
         name: Jungle Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 12]
+        tex: [5, 3]
 
       4: # bit 0x4 - "Decaying"
         name: Leaves (Decaying)
         mapcolor: [60, 192, 41]
-        tex: [5, 3]
+        tex: [2, 3]
       5:
         name: Pine Leaves (Decaying)
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 8]
+        tex: [3, 3]
       6:
         name: Birch Leaves (Decaying)
         mapcolor: [89, 151, 76]
-        tex: [5, 3]
+        tex: [4, 3]
       7:
         name: Jungle Leaves (Decaying)
         mapcolor: [74, 131, 66]
-        tex: [5, 12]
-      4: # bit 0x8 - "Permanent"
+        tex: [5, 3]
+
+      8: # bit 0x8 - "Permanent"
         name: Leaves (Permanent)
         mapcolor: [60, 192, 41]
-        tex: [5, 3]
-      5:
+        tex: [2, 3]
+      9:
         name: Pine Leaves (Permanent)
         aka: Spruce Leaves
         mapcolor: [74, 131, 66]
-        tex: [5, 8]
-      6:
+        tex: [3, 3]
+      10:
         name: Birch Leaves (Permanent)
         mapcolor: [89, 151, 76]
-        tex: [5, 3]
-      7:
+        tex: [4, 3]
+      11:
         name: Jungle Leaves (Permanent)
         mapcolor: [74, 131, 66]
-        tex: [5, 12]
+        tex: [5, 3]
 
   - id: 19
     idStr: sponge
     name: Sponge
     mapcolor: [193, 193, 57]
-    tex: [0, 3]
+    tex: [24, 2]
 
   - id: 20
     idStr: GLASS
     name: Glass
     mapcolor: [255, 255, 255]
-    tex: [1, 3]
+    tex: [25, 2]
     type: GLASS
     opacity: 0
 
@@ -251,73 +256,71 @@ blocks:
     idStr: LAPIS_LAZULI_ORE
     name: Lapis Lazuli Ore
     mapcolor: [27, 70, 161]
-    tex: [0, 10]
+    tex: [3, 2]
 
   - id: 22
     idStr: LAPIS_LAZULI_BLOCK
     name: Lapis Lazuli Block
     mapcolor: [0, 0, 0]
-    tex: [0, 9]
+    tex: [20 ,1]
 
   - id: 24
     idStr: SANDSTONE
     name: Sandstone
     mapcolor: [218, 210, 158]
-    tex: [0, 12]
+    tex: [15, 0]
     tex_direction:
-      TOP: [0, 11]
-      BOTTOM: [0, 13]
+      TOP: [18, 0]
+      BOTTOM: [19, 0]
     data:
       0:
         name: Sandstone
         mapcolor: [218, 210, 158]
-        tex: [0, 12]
+        tex: [15, 0]
       1:
         name: Sandstone
         aka: Decorative Sandstone
         mapcolor: [218, 210, 158]
-        tex: [5, 14]
+        tex: [16, 0]
         tex_direction:
-          TOP: [0, 11]
-          BOTTOM: [0, 11]
+          TOP: [18, 0]
+          BOTTOM: [19, 0]
       2:
         name: Sandstone
         aka: Smooth Sandstone
         mapcolor: [218, 210, 158]
-        tex: [6, 14]
+        tex: [17, 0]
         tex_direction:
-          TOP: [0, 11]
-          BOTTOM: [0, 11]
+          TOP: [18, 0]
+          BOTTOM: [19, 0]
 
   - id: 26
     idStr: BED
     name: Bed
     mapcolor: [255, 0, 0]
-    tex: [7, 8]
+    tex: [8. 5]
     type: BED
     tex_extra:
-      foot_top: [6, 8]
-      head_side: [7, 9]
-      foot_side: [6, 9]
-      foot: [5, 9]
-      head: [8, 9]
+      foot_top: [5, 5]
+      head_side: [10, 5]
+      foot_side: [7, 5]
+      foot: [6, 5]
+      head: [9, 5]
     opacity: 0
 
   - id: 27
     idStr: goldenRail
     name: Powered Rail
     mapcolor: [120, 53, 28]
-    tex: [3, 11]
+    tex: [0, 5]
     type: SIMPLE_RAIL
-    tex_extra:
-      powered: [3, 11]
     opacity: 0
 
   - id: 30
     idStr: WEB
     name: Web
     mapcolor: [255, 255, 255]
-    tex: [11, 0]
+    tex: [1, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -328,13 +331,13 @@ blocks:
     tex: [7, 2]
     data:
       0:
-        tex: [7, 3]
-        name: (Unused Shrub)
+        tex: [11, 2]
+        name: Tall Grass
       1:
-        tex: [7, 2]
+        tex: [11, 2]
         name: Tall Grass
       2:
-        tex: [8, 3]
+        tex: [12, 2]
         name: Fern
     type: DECORATION_CROSS
     opacity: 0
@@ -343,7 +346,7 @@ blocks:
     idStr: deadbush
     name: Dead Shrub
     mapcolor: [148, 100, 40]
-    tex: [7, 3]
+    tex: [9, 2]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -351,87 +354,87 @@ blocks:
     idStr: WOOL
     name: White Wool
     mapcolor: [222, 222, 222]
-    tex: [0, 4]
+    tex: [24, 7]
     data:
-      0:
-        tex: [0, 4]
+      0: 
+        tex: [24, 7]
         name: White Wool
         mapcolor: [222, 222, 222]
-      1:
-        tex: [2, 13]
+      1: 
+        tex: [25, 7]
         name: Orange Wool
         mapcolor: [234, 127, 55]
-      2:
-        tex: [2, 12]
+      2: 
+        tex: [26, 7]
         name: Magenta Wool
         mapcolor: [191, 75, 201]
-      3:
-        tex: [2, 11]
+      3: 
+        tex: [27, 7]
         name: Light Blue Wool
         aka: Aqua Wool
         mapcolor: [104, 139, 212]
-      4:
-        tex: [2, 10]
+      4: 
+        tex: [28, 7]
         name: Yellow Wool
         mapcolor: [104, 139, 212]
-      5:
-        tex: [2, 9]
+      5: 
+        tex: [29, 7]
         name: Lime Wool
         mapcolor: [59, 189, 48]
-      6:
-        tex: [2, 8]
+      6: 
+        tex: [30, 7]
         name: Pink Wool
         mapcolor: [217, 131, 155]
-      7:
-        tex: [2, 7]
+      7: 
+        tex: [31, 7]
         name: Gray Wool
         mapcolor: [66, 66, 66]
-      8:
-        tex: [1, 14]
+      8: 
+        tex: [0, 8]
         name: Light Gray Wool
         mapcolor: [166, 166, 166]
-      9:
-        tex: [1, 13]
+      9: 
+        tex: [1, 8]
         name: Cyan Wool
         mapcolor: [39, 117, 149]
-      10:
-        tex: [1, 12]
+      10: 
+        tex: [2, 8]
         name: Purple Wool
         aka: Indigo Wool, Violet Wool
         mapcolor: [129, 54, 196]
-      11:
-        tex: [1, 11]
+      11: 
+        tex: [3, 8]
         name: Blue Wool
         mapcolor: [39, 51, 161]
-      12:
-        tex: [1, 10]
+      12: 
+        tex: [4, 8]
         name: Brown Wool
         mapcolor: [86, 51, 28]
-      13:
-        tex: [1, 9]
+      13: 
+        tex: [5, 8]
         name: Green Wool
         mapcolor: [56, 77, 24]
-      14:
-        tex: [1, 8]
+      14: 
+        tex: [6, 8]
         name: Red Wool
         mapcolor: [164, 45, 41]
-      15:
-        tex: [1, 7]
+      15: 
+        tex: [7, 8]
         name: Black Wool
         mapcolor: [0, 0, 0]
 
   - id: 37
     idStr: YELLOW_FLOWER
-    name: Flower
+    name: Dandelion
     mapcolor: [255, 255, 0]
-    tex: [13, 0]
+    tex: [3, 1]
     type: DECORATION_CROSS
     opacity: 0
 
   - id: 38
     name: Rose
     mapcolor: [255, 0, 0]
-    tex: [12, 0]
+    tex: [2, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -439,7 +442,7 @@ blocks:
     idStr: BROWN_MUSHROOM
     name: Brown Mushroom
     mapcolor: [145, 109, 85]
-    tex: [13, 1]
+    tex: [31, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -447,7 +450,7 @@ blocks:
     idStr: RED_MUSHROOM
     name: Red Mushroom
     mapcolor: [226, 18, 18]
-    tex: [12, 1]
+    tex: [30, 1]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -455,13 +458,13 @@ blocks:
     idStr: GOLD_BLOCK
     name: Block of Gold
     mapcolor: [231, 165, 45]
-    tex: [7, 1]
+    tex: [17, 1]
 
   - id: 42
     idStr: IRON_BLOCK
     name: Block of Iron
     mapcolor: [191, 191, 191]
-    tex: [6, 1]
+    tex: [16, 1]
 
   - id: 43
     idStr: DOUBLE_SLAB
@@ -470,36 +473,36 @@ blocks:
     mapcolor: [200, 200, 200]
     tex: [5, 0]
     tex_direction:
-      TOP: [6, 0]
-      BOTTOM: [6, 0]
-      FORWARD: [5, 0]
-      BACKWARD: [5, 0]
-      SIDES: [5, 0]
+      TOP: [26, 0]
+      BOTTOM: [26, 0]
+      FORWARD: [27, 0]
+      BACKWARD: [27, 0]
+      SIDES: [27, 0]
 
     data:
-      0:
-        tex: [5, 0]
+      0: 
+        tex: [27, 0]
         name: Double Stone Slab
-      1:
-        tex: [0, 12]
+      1: 
+        tex: [15, 0]
         name: Double Sandstone Slab
-      2:
-        tex: [4, 0]
+      2: 
+        tex: [22, 0]
         name: Double Wooden Slab
-      3:
-        tex: [0, 1]
+      3: 
+        tex: [5, 0]
         name: Double Cobblestone Slab
-      4:
-        tex: [7, 0]
+      4: 
+        tex: [28, 0]
         name: Double Brick Slab
       5:
-        tex: [6, 3]
+        tex: [7, 0]
         name: Double Stone Brick Slab
       6:
-        tex: [9, 13]
+        tex: [25, 1]
         name: Double Quartz Slab
       7:
-        tex: [9, 13]
+        tex: [26, 0]
         name: Double Solid Stone Slab
 
   - id: 44
@@ -515,29 +518,29 @@ blocks:
       BACKWARD: [5, 0]
       SIDES: [5, 0]
     data:
-      0:
-        tex: [6, 0]
+      0: 
+        tex: [27, 0]
         name: Stone Slab
-      1:
-        tex: [0, 12]
+      1: 
+        tex: [15, 0]
         name: Sandstone Slab
-      2:
-        tex: [4, 0]
+      2: 
+        tex: [22, 0]
         name: Wooden Slab
-      3:
-        tex: [0, 1]
+      3: 
+        tex: [5, 0]
         name: Cobblestone Slab
-      4:
-        tex: [7, 0]
+      4: 
+        tex: [28, 0]
         name: Brick Slab
       5:
-        tex: [6, 3]
+        tex: [7, 0]
         name: Stone Brick Slab
       6:
-        tex: [9, 13]
+        tex: [25, 1]
         name: Quartz Slab
       7:
-        tex: [9, 13]
+        tex: [26, 0]
         name: Solid Stone Slab
     type: HALFHEIGHT
 
@@ -545,44 +548,44 @@ blocks:
     idStr: BRICK
     name: Brick
     mapcolor: [170, 86, 62]
-    tex: [7, 0]
+    tex: [28, 0]
 
   - id: 46
     idStr: TNT
     name: TNT
     mapcolor: [160, 83, 65]
-    tex: [8, 0]
+    tex: [29, 0]
     tex_direction:
-      TOP: [9, 0]
-      BOTTOM: [10, 0]
+      TOP: [30, 0]
+      BOTTOM: [31, 0]
 
   - id: 47
     idStr: BOOKSHELF
     name: Bookshelf
     mapcolor: [188, 152, 98]
-    tex: [3, 2]
+    tex: [0, 1]
     tex_direction:
-      TOP: [4, 0]
-      BOTTOM: [4, 0]
+      TOP: [22, 0]
+      BOTTOM: [22, 0]
 
   - id: 48
     idStr: MOSSY_COBBLESTONE
     name: Moss Stone
     aka: Mossy Cobblestone
     mapcolor: [115, 169, 115]
-    tex: [4, 2]
+    tex: [6, 0]
 
   - id: 49
     idStr: OBSIDIAN
     name: Obsidian
     mapcolor: [26, 11, 43]
-    tex: [5, 2]
+    tex: [12, 0]
 
   - id: 50
     idStr: TORCH
     name: Torch
     mapcolor: [245, 220, 50]
-    tex: [0, 5]
+    tex: [18, 3]
     type: TORCH
     explored: true
     opacity: 0
@@ -593,7 +596,7 @@ blocks:
     name: Fire
     mapcolor: [255, 170, 30]
     type: SEMISOLID
-    tex: [15, 1]
+    tex: [8, 8]
     opacity: 0
     brightness: 15
 
@@ -601,18 +604,18 @@ blocks:
     idStr: WOODEN_STAIRS
     name: Wooden Stairs
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     type: STAIRS
 
   - id: 54
     idStr: CHEST
     name: Chest
     mapcolor: [125, 91, 38]
-    tex: [11, 1]
+    tex: [20, 7]
     type: CHEST
     tex_extra:
-      side_small: [10, 1]
-      top: [9, 1]
+      side_small: [19, 7]
+      top: [18, 7]
       front_big_left: [9, 2]
       front_big_right: [10, 2]
       back_big_left: [9, 3]
@@ -623,85 +626,85 @@ blocks:
     idStr: DIAMOND_ORE
     name: Diamond Ore
     mapcolor: [129, 140, 143]
-    tex: [2, 3]
+    tex: [4, 2]
 
   - id: 57
     idStr: DIAMOND_BLOCK
     name: Block of Diamond
     mapcolor: [45, 166, 152]
-    tex: [8, 1]
+    tex: [18, 1]
 
   - id: 58
     idStr: WORKBENCH
     name: Crafting Table
     mapcolor: [114, 88, 56]
-    tex: [12, 3]
+    tex: [15, 2]
     tex_direction:
-      SIDES: [11, 3]
-      TOP: [11, 2]
-      BOTTOM: [4, 0]
+      SIDES: [14, 2]
+      TOP: [13, 2]
+      BOTTOM: [22, 0]
 
   - id: 59
     idStr: CROPS
     name: Crops
     aka: Wheat
     mapcolor: [146, 192, 0]
-    tex: [15, 5]
+    tex: [5, 4]
     type: CROPS
     data:
-      0: {tex: [8, 5]}
-      1: {tex: [9, 5]}
-      2: {tex: [10, 5]}
-      3: {tex: [11, 5]}
-      4: {tex: [12, 5]}
-      5: {tex: [13, 5]}
-      6: {tex: [14, 5]}
-      7: {tex: [15, 5]}
+      0: {tex: [30, 3]}
+      1: {tex: [31, 3]}
+      2: {tex: [0, 4]}
+      3: {tex: [1, 4]}
+      4: {tex: [2, 4]}
+      5: {tex: [3, 4]}
+      6: {tex: [4, 4]}
+      7: {tex: [5, 4]}
     opacity: 0
 
   - id: 60
     idStr: FARMLAND
     name: Farmland
     mapcolor: [95, 58, 30]
-    tex: [6, 5]
+    tex: [29, 3]
     tex_direction:
-      FORWARD: [2, 0]
-      SIDES: [2, 0]
-      BACKWARD: [2, 0]
-      BOTTOM: [2, 0]
+      FORWARD: [21, 0]
+      SIDES: [21, 0]
+      BACKWARD: [21, 0]
+      BOTTOM: [21, 0]
 
   - id: 61
     idStr: FURNACE
     name: Furnace
     mapcolor: [96, 96, 96]
-    tex: [12, 2]
+    tex: [16, 2]
     tex_direction:
-      FORWARD: [12, 2]
-      SIDES: [13, 2]
-      BACKWARD: [13, 2]
-      TOP: [14, 3]
-      BOTTOM: [14, 3]
+      FORWARD: [16, 0]
+      SIDES: [18, 0]
+      BACKWARD: [18, 0]
+      TOP: [19, 0]
+      BOTTOM: [19, 0]
     tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
 
   - id: 62
     idStr: BURNING_FURNACE
     name: Burning Furnace
     mapcolor: [96, 96, 96]
-    tex: [13, 3]
+    tex: [17, 2]
     tex_direction:
-      FORWARD: [13, 3]
-      SIDES: [13, 2]
-      BACKWARD: [13, 2]
-      TOP: [14, 3]
-      BOTTOM: [14, 3]
+      FORWARD: [16, 0]
+      SIDES: [18, 0]
+      BACKWARD: [18, 0]
+      TOP: [19, 0]
+      BOTTOM: [19, 0]
     tex_direction_data: {2: NORTH, 3: SOUTH, 4: WEST, 5: EAST}
     brightness: 14
-
+    
   - id: 63
     idStr: sign
     name: Sign
     mapcolor: [111, 91, 54]
-    tex: [4, 0]
+    tex: [22, 0]
     type: SIGNPOST
     opacity: 0
 
@@ -709,42 +712,42 @@ blocks:
     idStr: WOODEN_DOOR
     name: Wooden Door
     mapcolor: [136, 109, 67]
-    tex: [1, 5]
+    tex: [22, 3]
     type: DOOR
     tex_extra:
-      bottom: [1, 6]
+      bottom: [21, 3]
     opacity: 0
 
   - id: 65
     idStr: LADDER
     name: Ladder
     mapcolor: [181, 140, 64]
-    tex: [3, 5]
+    tex: [25, 3]
     type: LADDER
     opacity: 0
-
+    
   - id: 66
     idStr: rail
     name: Rail
     mapcolor: [150, 134, 102]
-    tex: [0, 8]
+    tex: [29, 4]
     type: MINECART_TRACKS
     tex_extra:
-      curve: [0, 7]
+      curve: [20, 4]
     opacity: 0
 
   - id: 67
     idStr: COBBLESTONE_STAIRS
     name: Stone Stairs
     mapcolor: [115, 115, 115]
-    tex: [0, 1]
+    tex: [5, 0]
     type: STAIRS
-
+    
   - id: 68
     idStr: sign
     name: Wall Sign
     mapcolor: [111, 91, 54]
-    tex: [4, 0]
+    tex: [22, 0]
     type: WALLSIGN
     opacity: 0
 
@@ -752,30 +755,30 @@ blocks:
     idStr: IRON_DOOR
     name: Iron Door
     mapcolor: [191, 191, 191]
-    tex: [2, 5]
+    tex: [24, 3]
     type: DOOR
     tex_extra:
-      bottom: [2, 6]
+      bottom: [23, 3]
     opacity: 0
 
   - id: 73
     idStr: REDSTONE_ORE
     name: Redstone Ore
     mapcolor: [131, 107, 107]
-    tex: [3, 3]
+    tex: [5, 2]
 
   - id: 74
     idStr: GLOWING_REDSTONE_ORE
     name: Redstone Ore (Glowing)
     mapcolor: [131, 107, 107]
-    tex: [3, 3]
+    tex: [5, 2]
     brightness: 9
 
   - id: 78
     idStr: SNOW
     name: Snow Layer
     mapcolor: [255, 255, 255]
-    tex: [2, 4]
+    tex: [7, 3]
     type: THINSLICE
     opacity: 0
 
@@ -783,7 +786,7 @@ blocks:
     idStr: ICE
     name: Ice
     mapcolor: [83, 113, 163]
-    tex: [3, 4]
+    tex: [8, 3]
     type: WATER
     opacity: 3
 
@@ -791,29 +794,29 @@ blocks:
     idStr: SNOW_BLOCK
     name: Snow
     mapcolor: [250, 250, 250]
-    tex: [2, 4]
+    tex: [7, 3]
 
   - id: 81
     idStr: CACTUS
     name: Cactus
     mapcolor: [25, 120, 25]
-    tex: [6, 4]
+    tex: [10, 3]
     tex_direction:
-      TOP: [5, 4]
-      BOTTOM: [5, 4]
+      TOP: [9, 3]
+      BOTTOM: [11, 3]
     opacity: 0
 
   - id: 82
     idStr: CLAY
     name: Clay
     mapcolor: [151, 157, 169]
-    tex: [8, 4]
+    tex: [13, 0]
 
   - id: 83
     idStr: SUGARCANE
     name: Sugar Cane
     mapcolor: [100, 67, 50]
-    tex: [9, 4]
+    tex: [12, 3]
     type: DECORATION_CROSS
     opacity: 0
 
@@ -821,7 +824,7 @@ blocks:
     idStr: FENCE
     name: Fence
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     type: FENCE
     opacity: 0
 
@@ -829,26 +832,26 @@ blocks:
     idStr: pumpkin
     name: Pumpkin
     mapcolor: [227, 144, 29]
-    tex: [7, 7]
+    tex: [9, 4]
     tex_direction:
-      FORWARD: [7, 7]
-      SIDES: [6, 7]
-      BACKWARD: [6, 7]
-      TOP: [6, 6]
-      BOTTOM: [6, 6]
+      FORWARD: [9, 4]
+      SIDES: [8, 4]
+      BACKWARD: [8, 4]
+      TOP: [7, 4]
+      BOTTOM: [7, 4]
     tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
 
   - id: 87
     idStr: hellrock
     name: Netherrack
     mapcolor: [104, 8, 8]
-    tex: [7, 6]
+    tex: [11, 4]
 
   - id: 89
     idStr: GLOWSTONE
     name: Glowstone
     mapcolor: [249, 212, 156]
-    tex: [9, 6]
+    tex: [17, 4]
     explored: true
     brightness: 15
 
@@ -857,13 +860,13 @@ blocks:
     name: Jack-o'-Lantern
     mapcolor: [249, 255, 58]
     explored: true
-    tex: [8, 7]
+    tex: [10, 4]
     tex_direction:
-      FORWARD: [8, 7]
-      SIDES: [6, 7]
-      BACKWARD: [6, 7]
-      TOP: [6, 6]
-      BOTTOM: [6, 6]
+      FORWARD: [9, 4]
+      SIDES: [8, 4]
+      BACKWARD: [8, 4]
+      TOP: [7, 4]
+      BOTTOM: [7, 4]
     tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
     brightness: 15
 
@@ -871,12 +874,12 @@ blocks:
     idStr: cake
     name: Cake
     mapcolor: [234, 233, 235]
-    tex: [9, 7]
+    tex: [19, 5]
     type: CAKE
     tex_extra:
-      side_uncut: [10, 7]
-      side_cut: [11, 7]
-      bottom: [12, 7]
+      side_uncut: [20 ,5]
+      side_cut: [18, 5]
+      bottom: [17, 5]
     opacity: 0
 
   - id: 95
@@ -887,7 +890,7 @@ blocks:
     idStr: TRAPDOOR
     name: Trapdoor
     mapcolor: [143, 107, 53]
-    tex: [4, 5]
+    tex: [26, 3]
     type: TRAPDOOR
     opacity: 0
 
@@ -895,26 +898,26 @@ blocks:
     idStr: STONE_BRICK
     name: Stone Bricks
     mapcolor: [120, 120, 120]
-    tex: [6, 3]
+    tex: [7, 0]
     data:
       0:
-        tex: [6, 3]
+        tex: [7, 0]
         name: Stone Bricks
       1:
-        tex: [4, 6]
+        tex: [8, 0]
         name: Mossy Stone Bricks
       2:
-        tex: [5, 6]
+        tex: [9, 0]
         name: Cracked Stone Bricks
       3:
-        tex: [5, 13]
+        tex: [10, 0]
         name: Circle Stone Bricks
 
   - id: 101
     idStr: fenceIron
     name: Iron Bars
     mapcolor: [77, 77, 78]
-    tex: [5, 5]
+    tex: [27, 3]
     type: SOLID_PANE
     opacity: 0
 
@@ -922,7 +925,7 @@ blocks:
     idStr: GLASS_PANE
     name: Glass Pane
     mapcolor: [255, 255, 255]
-    tex: [1, 3]
+    tex: [25, 2]
     type: SOLID_PANE
     opacity: 0
 
@@ -930,37 +933,37 @@ blocks:
     idStr: MELON
     name: Watermelon
     mapcolor: [190, 184, 41]
-    tex: [9, 8]
+    tex: [24, 4]
     tex_direction:
-      FORWARD: [8, 8]
-      SIDES: [8, 8]
-      BACKWARD: [8, 8]
+      FORWARD: [23, 4]
+      SIDES: [23, 4]
+      BACKWARD: [23, 4]
 
   - id: 104
     idStr: pumpkinStem
     name: Pumpkin Stem
     mapcolor: [227, 144, 29]
-    tex: [15, 6]
+    tex: [27, 4]
     type: STEM
     tex_extra:
-      curve: [15, 7]
+      curve: [28, 4]
     opacity: 0
 
   - id: 105
     idStr: MELON_STEM
     name: Melon Stem
     mapcolor: [190, 184, 41]
-    tex: [15, 6]
+    tex: [25, 4]
     type: STEM
     tex_extra:
-      curve: [15, 7]
+      curve: [26, 4]
     opacity: 0
 
   - id: 107
     idStr: FENCE_GATE
     name: Fence Gate
     mapcolor: [157, 128, 79]
-    tex: [4, 0]
+    tex: [22, 0]
     type: FENCE_GATE
     opacity: 0
 
@@ -968,69 +971,69 @@ blocks:
     idStr: BRICK_STAIRS
     name: Brick Stairs
     mapcolor: [170, 86, 62]
-    tex: [7, 0]
+    tex: [28, 0]
     type: STAIRS
-
+    
   - id: 109
     idStr: stairsStoneBrickSmooth
     name: Stone Brick Stairs
     mapcolor: [120, 120, 120]
-    tex: [6, 3]
+    tex: [7, 0]
     type: STAIRS
 
   - id: 112
     idStr: netherBrick
     name: Nether Brick
     mapcolor: [54, 24, 30]
-    tex: [0, 14]
-
+    tex: [12, 4]
+    
   - id: 114
     idStr: stairsNetherBrick
     name: Nether Stairs
     mapcolor: [54, 24, 30]
-    tex: [0, 14]
+    tex: [12, 4]
     type: STAIRS
 
   - id: 128
     idStr: stairsSandStone
     name: Sandstone Stairs
     mapcolor: [157, 128, 79]
-    tex: [0, 12]
+    tex: [15, 0]
     type: STAIRS
 
   - id: 134
     idStr: stairsWoodSpruce
     name: Spruce-Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [6, 12]
+    tex: [23, 0]
     type: STAIRS
 
   - id: 135
     idStr: stairsWoodBirch
     name: Birch-Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [6, 13]
+    tex: [24, 0]
     type: STAIRS
 
   - id: 136
     idStr: stairsWoodJungle
     name: Jungle-Wood Stairs
     mapcolor: [157, 128, 79]
-    tex: [7, 12]
+    tex: [25, 0]
     type: STAIRS
 
   - id: 139
     idStr: cobbleWall
     name: Cobblestone Wall
     mapcolor: [128, 128, 128]
-    tex: [0, 1]
+    tex: [5, 0]
     type: FENCE
     data:
       0:
-        tex: [0, 1]
+        tex: [5, 0]
         name: Cobblestone Wall
       1:
-        tex: [4, 2]
+        tex: [6, 0]
         name: Mossy Cobblestone Wall
     opacity: 0
 
@@ -1038,39 +1041,39 @@ blocks:
     idStr: carrots
     name: Carrots
     mapcolor: [200, 100, 100]
-    tex: [11, 11]
+    tex: [24, 6]
     type: CROPS
     data:
-      0: {tex: [8, 11]}
-      1: {tex: [9, 11]}
-      2: {tex: [10, 11]}
-      3: {tex: [11, 11]}
+      0: {tex: [21, 6]}
+      1: {tex: [22, 6]}
+      2: {tex: [23, 6]}
+      3: {tex: [24, 6]}
     opacity: 0
 
   - id: 142
     idStr: potatoes
     name: Potatoes
     mapcolor: [200, 100, 100]
-    tex: [12, 11]
+    tex: [28, 6]
     type: CROPS
     data:
-      0: {tex: [8, 11]}
-      1: {tex: [9, 11]}
-      2: {tex: [10, 11]}
-      3: {tex: [12, 11]}
+      0: {tex: [25, 6]}
+      1: {tex: [26, 6]}
+      2: {tex: [27, 6]}
+      3: {tex: [28, 6]}
     opacity: 0
 
   - id: 155
     idStr: quartzBlock
     name: Block of Quartz
     mapcolor: [255, 255, 255]
-    tex: [9, 13]
+    tex: [25, 1]
 
   - id: 156
     idStr: stairsQuartz
     name: Quartz Stairs
     mapcolor: [255, 255, 255]
-    tex: [9, 13]
+    tex: [25, 1]
     type: STAIRS
 
   - id: 157
@@ -1078,19 +1081,19 @@ blocks:
     name: Wooden Double Slab
     aka: Wood Double Step
     mapcolor: [200, 200, 200]
-    tex: [4, 0]
+    tex: [22, 0]
     data:
       0:
-        tex: [4, 0]
+        tex: [22, 0]
         name: Oak-Wood Double Slab
       1:
-        tex: [6, 12]
+        tex: [23, 0]
         name: Spruce-Wood Double Slab
       2:
-        tex: [6, 13]
+        tex: [24, 0]
         name: Birch-Wood Double Slab
       3:
-        tex: [7, 12]
+        tex: [25, 0]
         name: Jungle-Wood Double Slab
 
   - id: 158
@@ -1098,19 +1101,19 @@ blocks:
     name: Wooden Slab
     aka: Wood Half Step
     mapcolor: [200, 200, 200]
-    tex: [4, 0]
+    tex: [22, 0]
     data:
       0:
-        tex: [4, 0]
+        tex: [22, 0]
         name: Oak-Wood Slab
       1:
-        tex: [6, 12]
+        tex: [23, 0]
         name: Spruce-Wood Slab
       2:
-        tex: [6, 13]
+        tex: [24, 0]
         name: Birch-Wood Slab
       3:
-        tex: [7, 12]
+        tex: [25, 0]
         name: Jungle-Wood Slab
     type: HALFHEIGHT
 
@@ -1118,11 +1121,11 @@ blocks:
     name: Hay Block
     mapcolor: [206, 170, 28]
     tex_direction:
-      TOP: [7, 13]
-      FORWARD: [8, 13]
-      SIDES: [8, 13]
-      BACKWARD: [8, 13]
-      BOTTOM: [7, 13]
+      TOP: [11, 6]
+      FORWARD: [12, 6]
+      SIDES: [12, 6]
+      BACKWARD: [12, 6]
+      BOTTOM: [11, 6]
 
   - id: 171
     name: Carpet
@@ -1132,7 +1135,7 @@ blocks:
     idStr: blockcoal
     name: Block of Coal
     mapcolor: [100, 100, 100]
-    tex: [12, 13]
+    tex: [19, 1]
     opacity: 0
 
   - id: 245
@@ -1146,55 +1149,57 @@ blocks:
     idStr: GLOWING_OBSIDIAN
     name: Glowing Obsidian
     mapcolor: [155, 0, 0]
-    tex: [10, 13]
+    tex: [22, 2]
+    tex_direction:
+      FORWARD: [20, 2]
+      SIDES: [21, 2]
+      BACKWARD: [20, 2]
+      BOTTOM: [23, 2]
     brightness: 12
 
   - id: 247
     idStr: NETHER_REACTOR_CORE
     name: Nether Reactor Core
     mapcolor: [125, 210, 255]
-    tex: [10, 14]
+    tex: [4, 7]
     data:
-      0:
-        tex: [10, 14]
+      0: 
+        tex: [4, 7]
         name: Nether Reactor Core
-      1:
-        tex: [9, 14]
+      1: 
+        tex: [6, 7]
         name: Nether Reactor Core (Used)
 
   - id: 248
     idStr: UpdateGameBlock
     name: Update Game Block
     mapcolor: [201, 119, 240]
-    tex: [11, 8]
+    tex: [21, 7]
     opacity: 0
 
   - id: 249
     idStr: UpdateGameBlock
-    name: UpdateGameBlock
+    name: Update Game Block
     mapcolor: [201, 119, 240]
-    tex: [11, 8]
+    tex: [21, 7]
     opacity: 0
 
   - id: 253
     idStr: GRASS_CARRIED
     name: Error Grass
     mapcolor: [201, 119, 240]
-    tex: [11, 8]
     opacity: 0
 
   - id: 254
     idStr: LEAVES_CARRIED
     name: Error Leaves
     mapcolor: [201, 119, 240]
-    tex: [11, 8]
     opacity: 0
 
   - id: 255
     idStr: INFO_RESERVED6
     name: Error Stone
     mapcolor: [201, 119, 240]
-    tex: [11, 8]
     opacity: 0
 
 ...

--- a/pocket.yaml
+++ b/pocket.yaml
@@ -50,20 +50,17 @@ blocks:
     tex: [22, 0]
     data:
       0:
-        name: Wood Planks
-        aka: Oak Wood Planks
+        name: Oak Wood Planks
+        aka: Wood Planks
         tex: [22, 0]
       1:
-        name: Wood Planks
-        aka: Spruce Wood Planks
+        name: Spruce Wood Planks
         tex: [23, 0]
       2:
-        name: Wood Planks
-        aka: Birch Wood Planks
+        name: Birch Wood Planks
         tex: [24, 0]
       3:
-        name: Wood Planks
-        aka: Jungle Wood Planks
+        name: Jungle Wood Planks
         tex: [25, 0]
 
   - id: 6
@@ -75,7 +72,8 @@ blocks:
     opacity: 0
     data:
       0: 
-        name: Sapling
+        name: Oak Sapling
+        aka: Sapling
         tex: [4, 1]
       1: 
         name: Spruce Sapling
@@ -163,17 +161,85 @@ blocks:
       BOTTOM: [9, 1]
     data:
       0:
-        name: Wood
+        name: Oak Wood (Upright)
+        aka: Wood
         tex: [8, 1]
+        tex_direction:
+          TOP: [9, 1]
+          BOTTOM: [9, 1]
       1:
-        name: Pine Wood
-        aka: Spruce Wood, Redwood
+        name: Spruce Wood (Upright)
         tex: [12, 1]
+        tex_direction:
+          TOP: [13, 1]
+          BOTTOM: [13, 1]
       2:
-        name: Birch Wood
+        name: Birch Wood (Upright)
         tex: [10, 1]
+        tex_direction:
+          TOP: [11, 1]
+          BOTTOM: [11, 1]
       3:
-        name: Jungle Wood
+        name: Jungle Wood (Upright)
+        tex: [14, 1]
+        tex_direction:
+          TOP: [15, 1]
+          BOTTOM: [15, 1]
+      4:
+        name: Oak Wood (East/West)
+        tex: [8, 1]
+        tex_direction:
+          SIDES: [9, 1]
+      5:
+        name: Spruce Wood (East/West)
+        tex: [12, 1]
+        tex_direction:
+          SIDES: [13, 1]
+      6:
+        name: Birch Wood (East/West)
+        tex: [10, 1]
+        tex_direction:
+          SIDES: [10, 14]
+      7:
+        name: Jungle Wood (East/West)
+        tex: [14, 1]
+        tex_direction:
+          SIDES: [15, 1]
+      8:
+        name: Oak Wood (North/South)
+        tex: [8, 1]
+        tex_direction:
+          FORWARD: [9, 1]
+          BACKWARD: [9, 1]
+      9:
+        name: Spruce Wood (North/South)
+        tex: [12, 1]
+        tex_direction:
+          FORWARD: [13, 1]
+          BACKWARD: [13, 1]
+      10:
+        name: Birch Wood (North/South)
+        tex: [10, 1]
+        tex_direction:
+          FORWARD: [11, 1]
+          BACKWARD: [11, 1]
+      11:
+        name: Jungle Wood (North/South)
+        tex: [14, 1]
+        tex_direction:
+          FORWARD: [15, 1]
+          BACKWARD: [15, 1]
+      12:
+        name: Oak Wood (Bark Only)
+        tex: [8, 1]
+      13:
+        name: Spruce Wood (Bark Only)
+        tex: [12, 1]
+      14:
+        name: Birch Wood (Bark Only)
+        tex: [10, 1]
+      15:
+        name: Jungle Wood (Bark Only)
         tex: [14, 1]
 
   - id: 18
@@ -425,14 +491,14 @@ blocks:
 
   - id: 37
     idStr: YELLOW_FLOWER
-    name: Dandelion
+    name: Flower
     mapcolor: [255, 255, 0]
     tex: [3, 1]
     type: DECORATION_CROSS
     opacity: 0
 
   - id: 38
-    name: Rose
+    name: Poppy
     mapcolor: [255, 0, 0]
     tex: [2, 1]
     type: DECORATION_CROSS
@@ -468,80 +534,82 @@ blocks:
 
   - id: 43
     idStr: DOUBLE_SLAB
-    name: Double Stone Slab
+    name: Stone Slab (Double)
     aka: Step
     mapcolor: [200, 200, 200]
-    tex: [5, 0]
-    tex_direction:
-      TOP: [26, 0]
-      BOTTOM: [26, 0]
-      FORWARD: [27, 0]
-      BACKWARD: [27, 0]
-      SIDES: [27, 0]
-
+    tex: [27, 0]
     data:
       0: 
-        tex: [27, 0]
         name: Double Stone Slab
+        tex: [27, 0]
+        tex_direction:
+          TOP: [26, 0]
+          BOTTOM: [26, 0]
       1: 
-        tex: [15, 0]
         name: Double Sandstone Slab
+        tex: [15, 0]
+        tex_direction:
+          TOP: [0, 18]
+          BOTTOM: [0, 19]
       2: 
+        name: Double Wooden Slab (Old)
         tex: [22, 0]
-        name: Double Wooden Slab
       3: 
-        tex: [5, 0]
         name: Double Cobblestone Slab
+        tex: [5, 0]
       4: 
-        tex: [28, 0]
         name: Double Brick Slab
+        tex: [28, 0]
       5:
-        tex: [7, 0]
         name: Double Stone Brick Slab
+        tex: [7, 0]
       6:
-        tex: [25, 1]
         name: Double Quartz Slab
+        tex: [25, 1]
       7:
-        tex: [26, 0]
         name: Double Solid Stone Slab
+        tex: [26, 0]
 
   - id: 44
     idStr: SLAB
     name: Stone Slab
     aka: Half Step
     mapcolor: [200, 200, 200]
-    tex: [6, 0]
-    tex_direction:
-      TOP: [6, 0]
-      BOTTOM: [6, 0]
-      FORWARD: [5, 0]
-      BACKWARD: [5, 0]
-      SIDES: [5, 0]
+    tex: [27, 0]
     data:
       0: 
-        tex: [27, 0]
         name: Stone Slab
+        tex: [27, 0]
+        tex_direction:
+          TOP: [26, 0]
+          BOTTOM: [26, 0]
+          FORWARD: [27, 0]
+          BACKWARD: [27, 0]
+          SIDES: [27, 0]
       1: 
-        tex: [15, 0]
         name: Sandstone Slab
+        tex: [15, 0]
+        tex_direction:
+          TOP: [0, 18]
+          BOTTOM: [0, 19]
       2: 
-        tex: [22, 0]
         name: Wooden Slab
+        tex: [22, 0]
       3: 
-        tex: [5, 0]
         name: Cobblestone Slab
+        tex: [5, 0]
       4: 
-        tex: [28, 0]
         name: Brick Slab
+        tex: [28, 0]
       5:
-        tex: [7, 0]
         name: Stone Brick Slab
+        tex: [7, 0]
       6:
-        tex: [25, 1]
         name: Quartz Slab
+        tex: [25, 1]
       7:
-        tex: [26, 0]
         name: Solid Stone Slab
+        tex: [26, 0]
     type: HALFHEIGHT
 
   - id: 45
@@ -602,7 +670,7 @@ blocks:
 
   - id: 53
     idStr: WOODEN_STAIRS
-    name: Wooden Stairs
+    name: Oak Wood Stairs
     mapcolor: [157, 128, 79]
     tex: [22, 0]
     type: STAIRS
@@ -646,7 +714,7 @@ blocks:
 
   - id: 59
     idStr: CROPS
-    name: Crops
+    name: Wheat
     aka: Wheat
     mapcolor: [146, 192, 0]
     tex: [5, 4]
@@ -688,7 +756,7 @@ blocks:
 
   - id: 62
     idStr: BURNING_FURNACE
-    name: Burning Furnace
+    name: Lit Furnace
     mapcolor: [96, 96, 96]
     tex: [17, 2]
     tex_direction:
@@ -702,7 +770,7 @@ blocks:
     
   - id: 63
     idStr: sign
-    name: Sign
+    name: Sign Post
     mapcolor: [111, 91, 54]
     tex: [22, 0]
     type: SIGNPOST
@@ -729,6 +797,7 @@ blocks:
   - id: 66
     idStr: rail
     name: Rail
+    aka: Minecart Track
     mapcolor: [150, 134, 102]
     tex: [29, 4]
     type: MINECART_TRACKS
@@ -738,7 +807,7 @@ blocks:
 
   - id: 67
     idStr: COBBLESTONE_STAIRS
-    name: Stone Stairs
+    name: Cobblestone Stairs
     mapcolor: [115, 115, 115]
     tex: [5, 0]
     type: STAIRS
@@ -901,17 +970,17 @@ blocks:
     tex: [7, 0]
     data:
       0:
-        tex: [7, 0]
         name: Stone Bricks
+        tex: [7, 0]
       1:
-        tex: [8, 0]
         name: Mossy Stone Bricks
+        tex: [8, 0]
       2:
-        tex: [9, 0]
         name: Cracked Stone Bricks
+        tex: [9, 0]
       3:
-        tex: [10, 0]
         name: Circle Stone Bricks
+        tex: [10, 0]
 
   - id: 101
     idStr: fenceIron
@@ -933,11 +1002,10 @@ blocks:
     idStr: MELON
     name: Watermelon
     mapcolor: [190, 184, 41]
-    tex: [24, 4]
+    tex: [23, 4]
     tex_direction:
-      FORWARD: [23, 4]
-      SIDES: [23, 4]
-      BACKWARD: [23, 4]
+      TOP: [24, 4]
+      BOTTOM: [24, 4]
 
   - id: 104
     idStr: pumpkinStem
@@ -989,7 +1057,7 @@ blocks:
     
   - id: 114
     idStr: stairsNetherBrick
-    name: Nether Stairs
+    name: Nether Brick Stairs
     mapcolor: [54, 24, 30]
     tex: [12, 4]
     type: STAIRS
@@ -1003,21 +1071,21 @@ blocks:
 
   - id: 134
     idStr: stairsWoodSpruce
-    name: Spruce-Wood Stairs
+    name: Spruce Wood Stairs
     mapcolor: [157, 128, 79]
     tex: [23, 0]
     type: STAIRS
 
   - id: 135
     idStr: stairsWoodBirch
-    name: Birch-Wood Stairs
+    name: Birch Wood Stairs
     mapcolor: [157, 128, 79]
     tex: [24, 0]
     type: STAIRS
 
   - id: 136
     idStr: stairsWoodJungle
-    name: Jungle-Wood Stairs
+    name: Jungle Wood Stairs
     mapcolor: [157, 128, 79]
     tex: [25, 0]
     type: STAIRS
@@ -1030,11 +1098,11 @@ blocks:
     type: FENCE
     data:
       0:
-        tex: [5, 0]
         name: Cobblestone Wall
+        tex: [5, 0]
       1:
-        tex: [6, 0]
         name: Mossy Cobblestone Wall
+        tex: [6, 0]
     opacity: 0
 
   - id: 141
@@ -1068,6 +1136,21 @@ blocks:
     name: Block of Quartz
     mapcolor: [255, 255, 255]
     tex: [25, 1]
+    data:
+      0:
+        name: Block of Quartz
+      1:
+        name: Chiseled Quartz Block
+        tex: [1, 28]
+        tex_direction:
+          TOP: [1, 29]
+          BOTTOM: [1, 29]
+      2:
+        name: Pillar Quartz Block
+        tex: [1, 26]
+        tex_direction:
+          TOP: [1, 27]
+          BOTTOM: [1, 27]
 
   - id: 156
     idStr: stairsQuartz
@@ -1084,17 +1167,16 @@ blocks:
     tex: [22, 0]
     data:
       0:
-        tex: [22, 0]
-        name: Oak-Wood Double Slab
+        name: Double Oak Wood Slab
       1:
+        name: Double Spruce Wood Slab
         tex: [23, 0]
-        name: Spruce-Wood Double Slab
       2:
+        name: Double Birch Wood Slab
         tex: [24, 0]
-        name: Birch-Wood Double Slab
       3:
+        name: Double Jungle Wood Slab
         tex: [25, 0]
-        name: Jungle-Wood Double Slab
 
   - id: 158
     idStr: woodSlab
@@ -1104,31 +1186,96 @@ blocks:
     tex: [22, 0]
     data:
       0:
-        tex: [22, 0]
-        name: Oak-Wood Slab
+        name: Oak Wood Slab
       1:
+        name: Spruce Wood Slab
         tex: [23, 0]
-        name: Spruce-Wood Slab
       2:
+        name: Birch Wood Slab
         tex: [24, 0]
-        name: Birch-Wood Slab
       3:
+        name: Jungle Wood Slab
         tex: [25, 0]
-        name: Jungle-Wood Slab
     type: HALFHEIGHT
 
   - id: 170
     name: Hay Block
     mapcolor: [206, 170, 28]
+    tex: [11, 6]
     tex_direction:
-      TOP: [11, 6]
       FORWARD: [12, 6]
       SIDES: [12, 6]
       BACKWARD: [12, 6]
-      BOTTOM: [11, 6]
 
   - id: 171
     name: Carpet
+    tex: [24, 7]
+    data:
+      0: 
+        name: White Carpet
+        tex: [24, 7]
+        mapcolor: [222, 222, 222]
+      1: 
+        name: Orange Carpet
+        tex: [25, 7]
+        mapcolor: [234, 127, 55]
+      2: 
+        name: Magenta Carpet
+        tex: [26, 7]
+        mapcolor: [191, 75, 201]
+      3: 
+        name: Light Blue Carpet
+        tex: [27, 7]
+        mapcolor: [104, 139, 212]
+      4: 
+        name: Yellow Carpet
+        tex: [28, 7]
+        mapcolor: [104, 139, 212]
+      5: 
+        name: Lime Carpet
+        tex: [29, 7]
+        mapcolor: [59, 189, 48]
+      6: 
+        name: Pink Carpet
+        tex: [30, 7]
+        mapcolor: [217, 131, 155]
+      7: 
+        name: Gray Carpet
+        tex: [31, 7]
+        mapcolor: [66, 66, 66]
+      8: 
+        name: Light Gray Carpet
+        tex: [0, 8]
+        mapcolor: [166, 166, 166]
+      9: 
+        name: Cyan Carpet
+        tex: [1, 8]
+        mapcolor: [39, 117, 149]
+      10: 
+        name: Purple Carpet
+        tex: [2, 8]
+        mapcolor: [129, 54, 196]
+      11: 
+        name: Blue Carpet
+        tex: [3, 8]
+        mapcolor: [39, 51, 161]
+      12: 
+        name: Brown Carpet
+        tex: [4, 8]
+        mapcolor: [86, 51, 28]
+      13: 
+        name: Green Carpet
+        tex: [5, 8]
+        mapcolor: [56, 77, 24]
+      14: 
+        name: Red Carpet
+        tex: [6, 8]
+        mapcolor: [164, 45, 41]
+      15: 
+        name: Black Carpet
+        tex: [7, 8]
+        mapcolor: [0, 0, 0]
+    type: THINSLICE
     opacity: 0
 
   - id: 173
@@ -1136,25 +1283,23 @@ blocks:
     name: Block of Coal
     mapcolor: [100, 100, 100]
     tex: [19, 1]
-    opacity: 0
 
   - id: 245
     idStr: STONECUTTER
     name: Stonecutter
     mapcolor: [96, 96, 96]
-    tex: [11, 8]
-    opacity: 0
-
-  - id: 246
-    idStr: GLOWING_OBSIDIAN
-    name: Glowing Obsidian
-    mapcolor: [155, 0, 0]
     tex: [22, 2]
     tex_direction:
       FORWARD: [20, 2]
       SIDES: [21, 2]
       BACKWARD: [20, 2]
       BOTTOM: [23, 2]
+
+  - id: 246
+    idStr: GLOWING_OBSIDIAN
+    name: Glowing Obsidian
+    mapcolor: [155, 0, 0]
+    tex: [7, 7]
     brightness: 12
 
   - id: 247

--- a/pocket.yaml
+++ b/pocket.yaml
@@ -71,14 +71,14 @@ blocks:
     type: DECORATION_CROSS
     opacity: 0
     data:
-      0: 
+      0:
         name: Oak Sapling
         aka: Sapling
         tex: [4, 1]
-      1: 
+      1:
         name: Spruce Sapling
         tex: [6, 1]
-      2: 
+      2:
         name: Birch Sapling
         tex: [5, 1]
 
@@ -102,14 +102,14 @@ blocks:
     name: Water
     mapcolor: [38, 92, 255]
     type: WATER
-    tex: [15, 12]
+    tex: [22, 7]
     opacity: 3
 
   - id: 10
     idStr: LAVA
     name: Lava (Flowing)
     mapcolor: [255, 90, 0]
-    tex: [22, 7]
+    tex: [23, 7]
     type: SEMISOLID
     brightness: 15
 
@@ -199,7 +199,7 @@ blocks:
         name: Birch Wood (East/West)
         tex: [10, 1]
         tex_direction:
-          SIDES: [10, 14]
+          SIDES: [11, 1]
       7:
         name: Jungle Wood (East/West)
         tex: [14, 1]
@@ -333,33 +333,28 @@ blocks:
     idStr: SANDSTONE
     name: Sandstone
     mapcolor: [218, 210, 158]
-    tex: [0, 12]
+    tex: [15, 0]
     tex_direction:
-      TOP: [0, 11]
-      BOTTOM: [0, 13]
+      TOP: [18, 0]
+      BOTTOM: [19, 0]
     data:
       0:
         name: Sandstone
-        mapcolor: [218, 210, 158]
-        tex: [0, 12]
-        tex_direction:
-          TOP: [0, 11]
-          BOTTOM: [0, 13]
       1:
         name: Chiseled Sandstone
         aka: Decorative Sandstone
         mapcolor: [218, 210, 158]
-        tex: [5, 14]
+        tex: [16, 0]
         tex_direction:
-          TOP: [0, 11]
-          BOTTOM: [0, 11]
+          TOP: [18, 0]
+          BOTTOM: [19, 0]
       2:
         name: Smooth Sandstone
         mapcolor: [218, 210, 158]
-        tex: [6, 14]
+        tex: [17, 0]
         tex_direction:
-          TOP: [0, 11]
-          BOTTOM: [0, 11]
+          TOP: [18, 0]
+          BOTTOM: [19, 0]
 
   - id: 26
     idStr: BED
@@ -425,69 +420,69 @@ blocks:
     mapcolor: [222, 222, 222]
     tex: [24, 7]
     data:
-      0: 
+      0:
         tex: [24, 7]
         name: White Wool
         mapcolor: [222, 222, 222]
-      1: 
+      1:
         tex: [25, 7]
         name: Orange Wool
         mapcolor: [234, 127, 55]
-      2: 
+      2:
         tex: [26, 7]
         name: Magenta Wool
         mapcolor: [191, 75, 201]
-      3: 
+      3:
         tex: [27, 7]
         name: Light Blue Wool
         aka: Aqua Wool
         mapcolor: [104, 139, 212]
-      4: 
+      4:
         tex: [28, 7]
         name: Yellow Wool
         mapcolor: [104, 139, 212]
-      5: 
+      5:
         tex: [29, 7]
         name: Lime Wool
         mapcolor: [59, 189, 48]
-      6: 
+      6:
         tex: [30, 7]
         name: Pink Wool
         mapcolor: [217, 131, 155]
-      7: 
+      7:
         tex: [31, 7]
         name: Gray Wool
         mapcolor: [66, 66, 66]
-      8: 
+      8:
         tex: [0, 8]
         name: Light Gray Wool
         mapcolor: [166, 166, 166]
-      9: 
+      9:
         tex: [1, 8]
         name: Cyan Wool
         mapcolor: [39, 117, 149]
-      10: 
+      10:
         tex: [2, 8]
         name: Purple Wool
         aka: Indigo Wool, Violet Wool
         mapcolor: [129, 54, 196]
-      11: 
+      11:
         tex: [3, 8]
         name: Blue Wool
         mapcolor: [39, 51, 161]
-      12: 
+      12:
         tex: [4, 8]
         name: Brown Wool
         mapcolor: [86, 51, 28]
-      13: 
+      13:
         tex: [5, 8]
         name: Green Wool
         mapcolor: [56, 77, 24]
-      14: 
+      14:
         tex: [6, 8]
         name: Red Wool
         mapcolor: [164, 45, 41]
-      15: 
+      15:
         tex: [7, 8]
         name: Black Wool
         mapcolor: [0, 0, 0]
@@ -554,13 +549,13 @@ blocks:
         tex_direction:
           TOP: [0, 18]
           BOTTOM: [0, 19]
-      2: 
+      2:
         name: Double Wooden Slab (Old)
         tex: [22, 0]
-      3: 
+      3:
         name: Double Cobblestone Slab
         tex: [5, 0]
-      4: 
+      4:
         name: Double Brick Slab
         tex: [28, 0]
       5:
@@ -592,13 +587,13 @@ blocks:
         tex_direction:
           TOP: [0, 18]
           BOTTOM: [0, 19]
-      2: 
+      2:
         name: Wooden Slab
         tex: [22, 0]
-      3: 
+      3:
         name: Cobblestone Slab
         tex: [5, 0]
-      4: 
+      4:
         name: Brick Slab
         tex: [28, 0]
       5:
@@ -718,25 +713,25 @@ blocks:
 #       null
 #     1:
 #       null
-      2: 
+      2:
         name: Chest (North)
         tex_direction:
           FORWARD: [20, 7]
           TOP: [18, 7]
           BOTTOM: [18, 7]
-      3: 
+      3:
         name: Chest (South)
         tex_direction:
           BACKWARD: [20, 7]
           TOP: [18, 7]
           BOTTOM: [18, 7]
-      4: 
+      4:
         name: Chest (West)
         tex_direction:
           LEFT: [20, 7]
           TOP: [18, 7]
           BOTTOM: [18, 7]
-      5: 
+      5:
         name: Chest (East)
         tex_direction:
           RIGHT: [20, 7]
@@ -807,25 +802,25 @@ blocks:
 #       null
 #     1:
 #       null
-      2: 
+      2:
         name: Furnace (North)
         tex_direction:
           FORWARD: [16, 2]
           TOP: [19, 2]
           BOTTOM: [19, 2]
-      3: 
+      3:
         name: Furnace (South)
         tex_direction:
           BACKWARD: [16, 2]
           TOP: [19, 2]
           BOTTOM: [19, 2]
-      4: 
+      4:
         name: Furnace (West)
         tex_direction:
           LEFT: [16, 2]
           TOP: [19, 2]
           BOTTOM: [19, 2]
-      5: 
+      5:
         name: Furnace (East)
         tex_direction:
           RIGHT: [16, 2]
@@ -843,25 +838,25 @@ blocks:
 #       null
 #     1:
 #       null
-      2: 
+      2:
         name: Lit Furnace (North)
         tex_direction:
           FORWARD: [17 ,2]
           TOP: [19, 2]
           BOTTOM: [19, 2]
-      3: 
+      3:
         name: Lit Furnace (South)
         tex_direction:
           BACKWARD: [17 ,2]
           TOP: [19, 2]
           BOTTOM: [19, 2]
-      4: 
+      4:
         name: Lit Furnace (West)
         tex_direction:
           LEFT: [17 ,2]
           TOP: [19, 2]
           BOTTOM: [19, 2]
-      5: 
+      5:
         name: Lit Furnace (East)
         tex_direction:
           RIGHT: [17 ,2]
@@ -1005,25 +1000,25 @@ blocks:
     tex: [8, 4]
 #   tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
     data:
-      0: 
+      0:
         name: Pumpkin (South)
         tex_direction:
           BACKWARD: [9, 4]
           TOP: [7, 4]
           BOTTOM: [7, 4]
-      1: 
+      1:
         name: Pumpkin (West)
         tex_direction:
           LEFT: [9, 4]
           TOP: [7, 4]
           BOTTOM: [7, 4]
-      2: 
+      2:
         name: Pumpkin (North)
         tex_direction:
           FORWARD: [9, 4]
           TOP: [7, 4]
           BOTTOM: [7, 4]
-      3: 
+      3:
         name: Pumpkin (East)
         tex_direction:
           RIGHT: [9, 4]
@@ -1052,25 +1047,25 @@ blocks:
     tex: [8, 4]
 #   tex_direction_data: {0: SOUTH, 1: WEST, 2: NORTH, 3: EAST}
     data:
-      0: 
+      0:
         name: Jack-o'-Lantern (South)
         tex_direction:
           BACKWARD: [10, 4]
           TOP: [7, 4]
           BOTTOM: [7, 4]
-      1: 
+      1:
         name: Jack-o'-Lantern (West)
         tex_direction:
           LEFT: [10, 4]
           TOP: [7, 4]
           BOTTOM: [7, 4]
-      2: 
+      2:
         name: Jack-o'-Lantern (North)
         tex_direction:
           FORWARD: [10, 4]
           TOP: [7, 4]
           BOTTOM: [7, 4]
-      3: 
+      3:
         name: Jack-o'-Lantern (East)
         tex_direction:
           RIGHT: [10, 4]
@@ -1180,7 +1175,7 @@ blocks:
     mapcolor: [170, 86, 62]
     tex: [28, 0]
     type: STAIRS
-    
+
   - id: 109
     idStr: stairsStoneBrickSmooth
     name: Stone Brick Stairs
@@ -1193,7 +1188,7 @@ blocks:
     name: Nether Brick
     mapcolor: [54, 24, 30]
     tex: [12, 4]
-    
+
   - id: 114
     idStr: stairsNetherBrick
     name: Nether Brick Stairs
@@ -1280,20 +1275,20 @@ blocks:
         name: Block of Quartz
         tex: [25, 1]
         tex_direction:
-          TOP: [1, 24]
-          BOTTOM: [1, 23]
+          TOP: [24, 1]
+          BOTTOM: [23, 1]
       1:
         name: Chiseled Quartz Block
-        tex: [1, 28]
+        tex: [28, 1]
         tex_direction:
-          TOP: [1, 29]
-          BOTTOM: [1, 29]
+          TOP: [29, 1]
+          BOTTOM: [29, 1]
       2:
         name: Pillar Quartz Block
-        tex: [1, 26]
+        tex: [26, 1]
         tex_direction:
-          TOP: [1, 27]
-          BOTTOM: [1, 27]
+          TOP: [27, 1]
+          BOTTOM: [27, 1]
 
   - id: 156
     idStr: quartz_stairs
@@ -1355,67 +1350,67 @@ blocks:
     type: THINSLICE
     opacity: 0
     data:
-      0: 
+      0:
         name: White Carpet
         tex: [24, 7]
         mapcolor: [222, 222, 222]
-      1: 
+      1:
         name: Orange Carpet
         tex: [25, 7]
         mapcolor: [234, 127, 55]
-      2: 
+      2:
         name: Magenta Carpet
         tex: [26, 7]
         mapcolor: [191, 75, 201]
-      3: 
+      3:
         name: Light Blue Carpet
         tex: [27, 7]
         mapcolor: [104, 139, 212]
-      4: 
+      4:
         name: Yellow Carpet
         tex: [28, 7]
         mapcolor: [104, 139, 212]
-      5: 
+      5:
         name: Lime Carpet
         tex: [29, 7]
         mapcolor: [59, 189, 48]
-      6: 
+      6:
         name: Pink Carpet
         tex: [30, 7]
         mapcolor: [217, 131, 155]
-      7: 
+      7:
         name: Gray Carpet
         tex: [31, 7]
         mapcolor: [66, 66, 66]
-      8: 
+      8:
         name: Light Gray Carpet
         tex: [0, 8]
         mapcolor: [166, 166, 166]
-      9: 
+      9:
         name: Cyan Carpet
         tex: [1, 8]
         mapcolor: [39, 117, 149]
-      10: 
+      10:
         name: Purple Carpet
         tex: [2, 8]
         mapcolor: [129, 54, 196]
-      11: 
+      11:
         name: Blue Carpet
         tex: [3, 8]
         mapcolor: [39, 51, 161]
-      12: 
+      12:
         name: Brown Carpet
         tex: [4, 8]
         mapcolor: [86, 51, 28]
-      13: 
+      13:
         name: Green Carpet
         tex: [5, 8]
         mapcolor: [56, 77, 24]
-      14: 
+      14:
         name: Red Carpet
         tex: [6, 8]
         mapcolor: [164, 45, 41]
-      15: 
+      15:
         name: Black Carpet
         tex: [7, 8]
         mapcolor: [0, 0, 0]

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@ from setuptools import setup
 from setuptools.extension import Extension
 from Cython.Distutils import build_ext
 
+from distutils.command.install import INSTALL_SCHEMES
+for scheme in INSTALL_SCHEMES.values():
+    scheme['data'] = scheme['purelib']
+
 import numpy
 
 version = '0.1'
@@ -39,6 +43,7 @@ setup(name='pymclevel',
       ext_modules=ext_modules,
       include_dirs=numpy.get_include(),
       include_package_data=True,
+      package_data={'pymclevel': ['*.yaml']},
       zip_safe=False,
       install_requires=install_requires,
       cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
I was surprised a bit when I tried to put a melon slice item in a chest and ended up with a melon block item.  On investigation, they both used the name "Melon".  This patch should allow them to be referenced separately.
