### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/nbt.py
+++ b/nbt.py
@@ -487,9 +487,10 @@ class TAG_List(TAG_Value, collections.MutableSequence):
         self.value.insert(index, value)
 
 
-tag_classes = { c.tagID: c for c in (TAG_Byte, TAG_Short, TAG_Int, TAG_Long, TAG_Float, TAG_Double, TAG_String,
-    TAG_Byte_Array, TAG_List, TAG_Compound, TAG_Int_Array, TAG_Short_Array) }
+tag_classes = {}
 
+for c in (TAG_Byte, TAG_Short, TAG_Int, TAG_Long, TAG_Float, TAG_Double, TAG_String, TAG_Byte_Array, TAG_List, TAG_Compound, TAG_Int_Array, TAG_Short_Array):
+    tag_classes[c.tagID] = c
 
 
 def gunzip(data):


### PR DESCRIPTION
As there is only one line that prohibits using python 2.6 here a small change that restores compatibility.

Reasons why dictionary comprehensions are only added in Python 2.7 see https://docs.python.org/3.5/whatsnew/2.7.html#other-language-changes

The dictionary comprehension has been replaced with a for loop.
