### PR TITLE
Specify package_data in setup.py (minecraft.yaml must be included).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(name='pymclevel',
       package_data= {
         "pymclevel": [
             "minecraft.yaml",
+            "pocket.yaml",
+            "classic.yaml",
+            "indev.yaml",
             "README.txt",
             "LICENSE.txt"
         ]},

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,12 @@ setup(name='pymclevel',
       license='MIT License',
       package_dir={'pymclevel': '.'},
       packages=["pymclevel"],
+      package_data= {
+        "pymclevel": [
+            "minecraft.yaml",
+            "README.txt",
+            "LICENSE.txt"
+        ]},
       ext_modules=ext_modules,
       include_dirs=numpy.get_include(),
       include_package_data=True,


### PR DESCRIPTION
pymclevel requires `minecraft.yaml` to be shipped, otherwise we obtain

```
IOError: [Errno 2] No such file or directory: 'pymclevel/minecraft.yaml'
```

This is currently happening if installing pymclevel right from git via pip (i.e. via `$ pip install git+git://github.com/mcedit/pymclevel.git`). By default, only Python files are included in the distribution build. There is a canonical mechanism for including non-Python files into the distribution build, as explained here: https://docs.python.org/2/distutils/setupscript.html#installing-package-data

I have used the `package_data` method in order to include `minecraft.yaml` and the license as well as readme into the dist build. This is currently untested, but this method generally works for my packages.
