### PR TITLE
Included .yaml files in install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@ from setuptools import setup
 from setuptools.extension import Extension
 from Cython.Distutils import build_ext
 
+from distutils.command.install import INSTALL_SCHEMES
+for scheme in INSTALL_SCHEMES.values():
+    scheme['data'] = scheme['purelib']
+
 import numpy
 
 version = '0.1'
@@ -39,6 +43,7 @@ setup(name='pymclevel',
       ext_modules=ext_modules,
       include_dirs=numpy.get_include(),
       include_package_data=True,
+      package_data={'pymclevel': ['*.yaml']},
       zip_safe=False,
       install_requires=install_requires,
       cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
This adds the four .yaml files to the distribution and installs them in the appropriate directory.

If schematics/ is also desired, it looks like each of the files under it can be listed separately, or a per-directory *.schematic can be added.
